### PR TITLE
fix: prevent O(n^2) explosion in cross-session matched-pace aggregation

### DIFF
--- a/meter.py
+++ b/meter.py
@@ -6604,9 +6604,10 @@ def opencode_summary(source, objs=None):
             message_rows = conn.execute(
                 "SELECT data, time_created FROM message WHERE session_id=? "
                 "AND json_extract(data,'$.role') IN ('user','assistant') "
-                "ORDER BY time_created ASC, id ASC",
+                "ORDER BY time_created DESC, id DESC LIMIT 500",
                 (sid,)
             ).fetchall()
+            message_rows.reverse()
     except (OSError, sqlite3.Error):
         row = None
         te = []
@@ -8830,26 +8831,29 @@ def aggregate_model_stats(session_rows):
                     target["ttft_samples"] += 1
                 context_tokens = int(sample.get("context_tokens") or 0)
                 if context_tokens > 0:
-                    target["workload_peak_inputs"].append(context_tokens)
-                    target["workload_tool_calls"].append(int(sample.get("tool_calls") or 0))
-                    target["workload_model_calls"].append(
-                        max(1, int(sample.get("model_calls") or 1))
-                    )
-                target["workload_peak_inputs"].append(peak_input_tokens)
-                target["workload_outputs"].append(output_tokens)
-                target["workload_tool_calls"].append(tool_calls)
-                target["workload_model_calls"].append(model_calls)
-                if metric_available(session, "cache"):
-                    target["workload_cache_ratios"].append(cache_ratio)
+                    if len(target["workload_peak_inputs"]) < 2000:
+                        target["workload_peak_inputs"].append(context_tokens)
+                        target["workload_tool_calls"].append(int(sample.get("tool_calls") or 0))
+                        target["workload_model_calls"].append(
+                            max(1, int(sample.get("model_calls") or 1))
+                        )
+                if len(target["workload_peak_inputs"]) < 2000:
+                    target["workload_peak_inputs"].append(peak_input_tokens)
+                    target["workload_outputs"].append(output_tokens)
+                    target["workload_tool_calls"].append(tool_calls)
+                    target["workload_model_calls"].append(model_calls)
+                    if metric_available(session, "cache"):
+                        target["workload_cache_ratios"].append(cache_ratio)
             if (not session.get("token_estimate") and duration_s > 0
                     and input_tokens > 0 and output_tokens > 0):
-                pace_groups[row["id"]].append({
-                    "day": day, "ts": float(sample.get("ts") or 0),
-                    "duration_s": duration_s, "input_tokens": input_tokens,
-                    "peak_input_tokens": peak_input_tokens,
-                    "output_tokens": output_tokens, "tool_calls": tool_calls,
-                    "model_calls": model_calls, "cache_read_tokens": cache_read_tokens,
-                })
+                if len(pace_groups[row["id"]]) < 500:
+                    pace_groups[row["id"]].append({
+                        "day": day, "ts": float(sample.get("ts") or 0),
+                        "duration_s": duration_s, "input_tokens": input_tokens,
+                        "peak_input_tokens": peak_input_tokens,
+                        "output_tokens": output_tokens, "tool_calls": tool_calls,
+                        "model_calls": model_calls, "cache_read_tokens": cache_read_tokens,
+                    })
             row["last_ts"] = max(float(row.get("last_ts") or 0), float(sample.get("ts") or 0))
         for sample in session.get("_wait_samples") or []:
             model = sample.get("model") or ""
@@ -8935,8 +8939,8 @@ def aggregate_model_stats(session_rows):
         row["daily"] = daily
         result.append(finalize_coverage(_finalize_throughput_fields(row)))
     result.sort(key=lambda row: (-row["output_tokens"], -row["input_tokens"],
-                                 -row["executions"], -row["wait_samples"],
-                                 row["model"], row["runtime"]))
+                                  -row["executions"], -row["wait_samples"],
+                                   row["model"], row["runtime"]))
     valid_ids = {row["id"] for row in result}
     projects = sorted({
         str(session.get("project") or "No project")
@@ -9154,6 +9158,11 @@ def cross_session(sources=None):
         for row in internal_rows
         for sample in (row.get("_wait_samples") or [])
     ])
+    _ms = aggregate_model_stats(internal_rows)
+    _ls = aggregate_language_signals(internal_rows)
+    _fr = aggregate_frustration(internal_rows)
+    _mp = model_pricing_settings()
+    _ci = capability_inventory(tool_waste)
     data = {
         "generated_at": int(now),
         "sessions": sessions[:60],
@@ -9196,16 +9205,16 @@ def cross_session(sources=None):
             }
             for k in provider_cost
         ], key=lambda r: -r["cost"]),
-        "model_stats": aggregate_model_stats(internal_rows),
-        "language_signals": aggregate_language_signals(internal_rows),
-        "frustration": aggregate_frustration(internal_rows),
-        "model_pricing": model_pricing_settings(),
+        "model_stats": _ms,
+        "language_signals": _ls,
+        "frustration": _fr,
+        "model_pricing": _mp,
         "budgets": budgets,
         "budget": budget,
         "tool_waste": tool_waste,
         "daily": daily,
         "monthly": monthly,
-        "capabilities": capability_inventory(tool_waste),
+        "capabilities": _ci,
         "session_actions": session_action_capability(),
     }
     _xsess["internal_rows"] = tuple(internal_rows)
@@ -11309,7 +11318,7 @@ class H(BaseHTTPRequestHandler):
             source = find_session(sid)
             st = cached_session_state(source) if source else None
             if st:
-                cross = cross_session()
+                cross = _xsess.get("data") or cross_session()
                 attach_cross_session(st, cross)
                 current_ids = {
                     str(row.get("id") or "")

--- a/tests/test_meter.py
+++ b/tests/test_meter.py
@@ -6,6 +6,7 @@ import plistlib
 import re
 import sqlite3
 import tempfile
+import time
 from pathlib import Path
 from unittest import mock
 
@@ -889,6 +890,56 @@ class ModelPerformanceTests(unittest.TestCase):
         self.assertFalse(different["available"])
         self.assertEqual(different["matched_pairs"], 0)
         self.assertIn("comparable turns", different["reason"])
+
+    def test_matched_pace_completes_under_large_sample_volume(self):
+        def sample(idx, duration):
+            return {
+                "duration_s": duration, "ts": 1000000 + idx * 60,
+                "day": "2026-08-01",
+                "input_tokens": 100000, "peak_input_tokens": 100000,
+                "cache_read_tokens": 70000, "output_tokens": 2000,
+                "tool_calls": 4, "model_calls": 3,
+            }
+        left = [sample(i, 10) for i in range(2000)]
+        right = [sample(i, 20) for i in range(2000)]
+        session_rows = [
+            {
+                "id": f"ses_{i}", "provider": "opencode",
+                "runtime": "OpenCode", "project": f"project-{i % 10}",
+                "availability": {"cost": True, "tokens": True, "cache": True},
+                "model_stats": [
+                    {"model": f"model-{i % 3}", "cost": 1.0, "tokens": 5000,
+                     "input_tokens": 3000, "output_tokens": 2000,
+                     "executions": 10, "availability": {"cost": True, "tokens": True}},
+                ],
+                "_model_daily": [],
+                "_performance_samples": left if i == 0 else [],
+                "_wait_samples": [],
+                "_tool_evidence": meter.summarize_tool_evidence([]),
+            }
+            for i in range(50)
+        ]
+        session_rows.append({
+            "id": "ses_big", "provider": "opencode",
+            "runtime": "OpenCode", "project": "big-project",
+            "availability": {"cost": True, "tokens": True, "cache": True},
+            "model_stats": [
+                {"model": "model-0", "cost": 50.0, "tokens": 250000,
+                 "input_tokens": 150000, "output_tokens": 100000,
+                 "executions": 500, "availability": {"cost": True, "tokens": True}},
+            ],
+            "_model_daily": [],
+            "_performance_samples": right,
+            "_wait_samples": [],
+            "_tool_evidence": meter.summarize_tool_evidence([]),
+        })
+        start = time.time()
+        result = meter.aggregate_model_stats(session_rows)
+        elapsed = time.time() - start
+        self.assertLess(elapsed, 5.0,
+                        f"aggregate_model_stats took {elapsed:.1f}s with 4000 samples; "
+                        "matched_pace_comparison may be unbounded")
+        self.assertGreaterEqual(len(result.get("models", [])), 1)
 
 
 class FrustrationSignalTests(unittest.TestCase):


### PR DESCRIPTION
## Problem

`cross_session()` took 155 seconds with 178 OpenCode sessions, causing the `/session` API endpoint to hang and the dashboard to show no cost data when viewing an OpenCode session detail page.

Root cause: `matched_pace_comparison` computed the full cross-product of every performance sample (~89K per model). Each pairwise comparison did billions of distance checks across four time windows.

## Fix

1. **`opencode_summary`**: cap message query at 500 rows to prevent unbounded reads during cross-session aggregation
2. **`aggregate_model_stats`**: cap workload lists at 2000 and pace-group samples at 500 per model to keep `matched_pace_windows` bounded
3. **`/session` handler**: reuse cached `_xsess` instead of rebuilding the full cross-session state on every detail-page request

## Result

`cross_session` cold build: **155s → 7.8s**

## Test

New test `test_matched_pace_completes_under_large_sample_volume` generates 4000 performance samples across 51 session rows and asserts `aggregate_model_stats` completes in under 5 seconds (runs in ~0.025s).

## Validation

- 295/295 tests pass (1 new)
- Installed runtime verified: `/health`, `/menubar`, `/session` all healthy
- Python compile, JS parse, shell syntax, Swift compile, whitespace check all pass