### PR TITLE
fix: Pi tool errors, reasoning split, context in use, and end-to-end pace

### DIFF
--- a/specs/ARCHITECTURE.md
+++ b/specs/ARCHITECTURE.md
@@ -99,12 +99,15 @@ aggregation never reopens traces or performs a second deduplication.
 
 The Pi adapter reads only Pi-owned JSONL session files and accepts a source only
 when it has the expected Pi session header. It projects recorded usage, local
-cost, structural tool evidence, and inferred user-to-assistant wait intervals
-without exposing message content. It uses a generic session title and collapses
-account-bearing provider resources, including application-profile references,
-to a safe model label. Pi does not establish a context window, output pace,
-semantic token split, or cache-savings price, so those projections remain
-unavailable rather than being derived or reported as zero.
+cost, structural tool evidence (including per-call error status), and inferred
+user-to-assistant wait intervals without exposing message content. Context in
+use and end-to-end output pace reuse the same request-usage and wall-clock
+evidence, with the output-pace diagnostic basis Claude already uses. It uses a
+generic session title and collapses account-bearing provider resources,
+including application-profile references, to a safe model label. Pi does not
+establish a context window size, time to first token, semantic token split, or
+cache-savings price, so those projections remain unavailable rather than being
+derived or reported as zero.
 
 ## Domain and Model Flow
 

--- a/tests/test_meter.py
+++ b/tests/test_meter.py
@@ -11896,7 +11896,7 @@ class PiRuntimeTests(unittest.TestCase):
     """Pi sessions are local JSONL records with no content projection."""
 
     def _write_session(self, agent_root, *, legacy=False, provider="anthropic",
-                       model="claude-test"):
+                       model="claude-test", result_error=False, reasoning_tokens=None):
         directory = Path(agent_root) if legacy else (
             Path(agent_root) / "sessions" / "--repo--"
         )
@@ -11923,8 +11923,12 @@ class PiRuntimeTests(unittest.TestCase):
              }},
             {"type": "message", "id": "result", "parentId": "assistant",
              "timestamp": "2026-09-04T10:00:06Z",
-             "message": {"role": "toolResult", "toolCallId": "call", "toolName": "read"}},
+             "message": {"role": "toolResult", "toolCallId": "call", "toolName": "read",
+                         **({"isError": True} if result_error else {})},
+             },
         ]
+        if reasoning_tokens is not None:
+            rows[3]["message"]["usage"]["reasoning"] = reasoning_tokens
         path.write_text("\n".join(json.dumps(row) for row in rows) + "\n")
         return path
 
@@ -11937,6 +11941,7 @@ class PiRuntimeTests(unittest.TestCase):
                     mock.patch.object(meter, "_RUNTIME_REGISTRY", None):
                 sources = meter.pi_session_sources()
                 state = meter.recompute(sources[0])
+                summary = meter.pi_summary(sources[0])
 
         self.assertEqual(len(sources), 1)
         self.assertEqual(sources[0]["provider"], "pi")
@@ -11951,8 +11956,6 @@ class PiRuntimeTests(unittest.TestCase):
         self.assertAlmostEqual(state["total_cost"], 0.0033)
         self.assertTrue(state["cost_approx"])
         self.assertTrue(state["availability"]["cost"])
-        self.assertFalse(state["availability"]["context"])
-        self.assertEqual(state["context"]["latest"], 0)
         self.assertFalse(state["semantic_available"])
         self.assertEqual(state["semantic"], {
             "reasoning": 0, "output": 0, "retrieval": 0, "coordination": 0,
@@ -11962,6 +11965,16 @@ class PiRuntimeTests(unittest.TestCase):
         self.assertIsNone(state["cache_saved"])
         self.assertTrue(state["wait_time"]["available"])
         self.assertEqual(state["executions"][0]["tools"][0]["name"], "read")
+        self.assertEqual(state["executions"][0]["context_tokens"], 115)
+        self.assertEqual(state["context"]["latest"], 115)
+        self.assertTrue(state["availability"]["context"])
+        self.assertTrue(state["availability"]["throughput"])
+        self.assertTrue(state["throughput"]["available"])
+        self.assertEqual(state["throughput"]["basis"], "end_to_end")
+        self.assertAlmostEqual(state["throughput"]["output_tps"], 20 / 3)
+        self.assertEqual(summary["context"]["latest"], 115)
+        self.assertEqual(summary["_context_samples"], [115])
+        self.assertTrue(summary["throughput"]["available"])
         self.assertNotIn("arguments", json.dumps(state))
 
     def test_redacts_pi_bedrock_application_profile_without_inferring_a_model(self):
@@ -12023,6 +12036,96 @@ class PiRuntimeTests(unittest.TestCase):
                     mock.patch.object(meter, "_pi_native_adapters", {}):
                 self.assertEqual(meter.pi_session_sources(), [])
                 self.assertEqual(meter.pi_session_sources(), [])
+
+    def test_records_pi_tool_result_errors_instead_of_successes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "agent"
+            self._write_session(root, result_error=True)
+            with mock.patch.object(meter, "PI_AGENT_DIR", str(root)), \
+                    mock.patch.object(meter, "_pi_native_adapters", {}), \
+                    mock.patch.object(meter, "_RUNTIME_REGISTRY", None):
+                source = meter.pi_session_sources()[0]
+                state = meter.recompute(source)
+                native = meter._pi_native_adapter().discover(None)[0]
+                session = meter._pi_native_adapter().load(native, meter.DetailLevel.FULL)
+
+        self.assertTrue(state["executions"][0]["tools"][0]["error"])
+        self.assertTrue(state["tools"]["total_errors"])
+        self.assertEqual(state["executions"][0]["tools"][0]["result_available"], True)
+        self.assertEqual(session.tools[0].status, "error")
+        self.assertEqual(
+            [event["severity"] for event in state["trace"] if event["kind"] == "tool_call"],
+            ["warn"],
+        )
+
+    def test_keeps_successful_pi_tool_results_as_successes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "agent"
+            self._write_session(root)
+            with mock.patch.object(meter, "PI_AGENT_DIR", str(root)), \
+                    mock.patch.object(meter, "_pi_native_adapters", {}), \
+                    mock.patch.object(meter, "_RUNTIME_REGISTRY", None):
+                source = meter.pi_session_sources()[0]
+                state = meter.recompute(source)
+                native = meter._pi_native_adapter().discover(None)[0]
+                session = meter._pi_native_adapter().load(native, meter.DetailLevel.FULL)
+
+        self.assertFalse(state["executions"][0]["tools"][0]["error"])
+        self.assertFalse(state["tools"]["total_errors"])
+        self.assertEqual(session.tools[0].status, "success")
+
+    def test_projects_pi_reasoning_tokens_as_an_output_subset(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "agent"
+            self._write_session(root, reasoning_tokens=12)
+            with mock.patch.object(meter, "PI_AGENT_DIR", str(root)), \
+                    mock.patch.object(meter, "_pi_native_adapters", {}), \
+                    mock.patch.object(meter, "_RUNTIME_REGISTRY", None):
+                source = meter.pi_session_sources()[0]
+                state = meter.recompute(source)
+
+        execution = state["executions"][0]
+        self.assertEqual(execution["reasoning_tokens"], 12)
+        self.assertEqual(state["series"][0]["reasoning"], 12)
+        self.assertTrue(state["series"][0]["think"])
+        # Reasoning is a reported subset of output, never an extra bucket.
+        self.assertEqual(state["total_tokens"], 135)
+        self.assertEqual(state["tokens"], {
+            "input": 100, "cache_write": 5, "cache_read": 10, "output": 20,
+        })
+
+    def test_clamps_pi_reasoning_tokens_to_reported_output(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "agent"
+            self._write_session(root, reasoning_tokens=999)
+            with mock.patch.object(meter, "PI_AGENT_DIR", str(root)), \
+                    mock.patch.object(meter, "_pi_native_adapters", {}), \
+                    mock.patch.object(meter, "_RUNTIME_REGISTRY", None):
+                state = meter.recompute(meter.pi_session_sources()[0])
+
+        self.assertEqual(state["executions"][0]["reasoning_tokens"], 20)
+        self.assertTrue(state["series"][0]["think"])
+
+    def test_keeps_pi_context_and_pace_unavailable_without_usage(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "agent"
+            path = self._write_session(root)
+            rows = [json.loads(line) for line in path.read_text().splitlines()]
+            del rows[3]["message"]["usage"]
+            path.write_text("\n".join(json.dumps(row) for row in rows) + "\n")
+            with mock.patch.object(meter, "PI_AGENT_DIR", str(root)), \
+                    mock.patch.object(meter, "_pi_native_adapters", {}), \
+                    mock.patch.object(meter, "_RUNTIME_REGISTRY", None):
+                source = meter.pi_session_sources()[0]
+                state = meter.recompute(source)
+                summary = meter.pi_summary(source)
+
+        self.assertEqual(state["context"]["latest"], 0)
+        self.assertFalse(state["availability"]["context"])
+        self.assertFalse(state["throughput"]["available"])
+        self.assertFalse(state["availability"]["throughput"])
+        self.assertEqual(summary["context"]["latest"], 0)
+        self.assertFalse(summary["throughput"]["available"])
 
     def test_keeps_cost_unavailable_when_a_pi_turn_lacks_its_local_estimate(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/token_meter/app.py
+++ b/token_meter/app.py
@@ -2589,6 +2589,7 @@ def _pi_compatibility():
         "add_model_summary": add_model_summary,
         "analysis_block": analysis_block,
         "build_state": build_state,
+        "context_sample_limit": CURRENT_SESSION_CONTEXT_SAMPLES,
         "metric_availability": metric_availability,
         "summarize_tool_evidence": summarize_tool_evidence,
         "summary_row": summary_row,

--- a/token_meter/runtimes/pi.py
+++ b/token_meter/runtimes/pi.py
@@ -28,7 +28,7 @@ from token_meter.contracts import (
     TurnSummary,
     UsageEvidence,
 )
-from token_meter.domain.timing import merge_execution_intervals
+from token_meter.domain.timing import merge_execution_intervals, performance_summary
 
 
 MAX_JSON_BYTES = 32 * 1024 * 1024
@@ -343,6 +343,8 @@ class PiRuntimeAdapter:
                 call = tools_by_call_id.get(str(message.get("toolCallId") or ""))
                 if call is not None:
                     call["result_available"] = True
+                    if message.get("isError") is True:
+                        call["error"] = True
             elif role == "assistant" and len(turns) < MAX_TURNS:
                 provider = str(message.get("provider") or provider)
                 model = str(message.get("model") or model)
@@ -351,6 +353,22 @@ class PiRuntimeAdapter:
                 output_tokens = _integer(usage.get("output"))
                 cache_read = _integer(usage.get("cacheRead"))
                 cache_write = _integer(usage.get("cacheWrite"))
+                # Pi reports reasoning as a subset of the output bucket.
+                reasoning_tokens = _integer(usage.get("reasoning")) or 0
+                if output_tokens is not None:
+                    reasoning_tokens = min(reasoning_tokens, output_tokens)
+                else:
+                    reasoning_tokens = 0
+                # Context in use is the request context Pi billed for, the
+                # same basis Claude projects; the window stays unknown.
+                context_available = (
+                    input_tokens is not None and cache_read is not None
+                    and cache_write is not None
+                )
+                context_tokens = (
+                    input_tokens + cache_read + cache_write
+                    if context_available else 0
+                )
                 token_available = input_tokens is not None and output_tokens is not None
                 cache_available = cache_read is not None and cache_write is not None
                 tools = []
@@ -363,6 +381,7 @@ class PiRuntimeAdapter:
                         "name": _normalize_tool_name(item.get("name")),
                         "category": _tool_category(item.get("name")),
                         "result_available": False,
+                        "error": False,
                     }
                     tools.append(tool)
                     if tool["id"]:
@@ -374,10 +393,13 @@ class PiRuntimeAdapter:
                     "model": model_ref_for(provider, model).model_id,
                     "input_tokens": input_tokens or 0,
                     "output_tokens": output_tokens or 0,
+                    "reasoning_tokens": reasoning_tokens,
                     "cache_read_tokens": cache_read or 0,
                     "cache_write_tokens": cache_write or 0,
                     "token_available": token_available,
                     "cache_available": cache_available,
+                    "context_available": context_available,
+                    "context_tokens": context_tokens,
                     "cost": _cost_breakdown(usage.get("cost")),
                     "tools": tools,
                 })
@@ -441,8 +463,11 @@ class PiRuntimeAdapter:
                 EvidenceValue.unavailable(),
             ),
             tools=tuple(
-                ToolEvent(tool["name"], tool["category"],
-                          "success" if tool.get("result_available") else None)
+                ToolEvent(
+                    tool["name"], tool["category"],
+                    "error" if tool.get("error")
+                    else "success" if tool.get("result_available") else None,
+                )
                 for turn in turns for tool in turn["tools"]
             )[:MAX_TOOLS],
             turns=tuple(
@@ -496,11 +521,9 @@ class PiRuntimeAdapter:
                     **ident, "id": tool["id"], "call_id": tool["id"],
                     "args_chars": 0, "output_chars": 0, "output_tokens": 0,
                     "result_available": bool(tool.get("result_available")),
-                    "error": False, "skills": [],
+                    "error": bool(tool.get("error")), "skills": [],
                 })
             total = sum(usage.values())
-            # Pi records request billing buckets, not verified context-window evidence.
-            context_tokens = 0
             timing_available = bool(turn["start"] and turn["end"] >= turn["start"])
             availability = compat["metric_availability"](
                 "pi", cost=cost_available, tokens=turn["token_available"],
@@ -515,9 +538,11 @@ class PiRuntimeAdapter:
                 "cost": execution_cost, "fresh_input": usage["input_tokens"],
                 "cache": usage["cache_read_input_tokens"] + usage["cache_creation_input_tokens"],
                 "cache_read": usage["cache_read_input_tokens"],
-                "cache_write": usage["cache_creation_input_tokens"], "think": False,
-                "tools": len(tools), "side": False, "reasoning": 0, "reasoning_ms": 0,
-                "context_pct": None, "context_tokens": context_tokens,
+                "cache_write": usage["cache_creation_input_tokens"],
+                "think": bool(turn["reasoning_tokens"]),
+                "tools": len(tools), "side": False,
+                "reasoning": turn["reasoning_tokens"], "reasoning_ms": 0,
+                "context_pct": None, "context_tokens": turn["context_tokens"],
                 "user_message": "", "user_input": "", "availability": availability,
             })
             executions.append({
@@ -533,8 +558,10 @@ class PiRuntimeAdapter:
                     "cache_write": usage["cache_creation_input_tokens"], "total": total,
                 },
                 "cost": execution_cost, "cost_breakdown": breakdown, "tools": tools,
-                "tool_count": len(tools), "model_calls": 1, "reasoning_tokens": 0,
-                "reasoning_duration_ms": 0, "context_tokens": context_tokens,
+                "tool_count": len(tools), "model_calls": 1,
+                "reasoning_tokens": turn["reasoning_tokens"],
+                "reasoning_duration_ms": 0,
+                "context_tokens": turn["context_tokens"],
                 "context_window": 0, "context_pct": None,
                 "duration_ms": duration * 1000 if duration else None,
                 "wait_duration_ms": duration * 1000 if duration else None,
@@ -552,7 +579,8 @@ class PiRuntimeAdapter:
             for tool in tools:
                 trace.append(compat["trace_event"](
                     turn["end"], "tool_call", tool["display"], "Payload excluded", turn["index"],
-                    tool=tool["name"], severity="tool", model=turn["model"],
+                    tool=tool["name"], severity="warn" if tool.get("error") else "tool",
+                    model=turn["model"],
                     native_type="tool_call", native_subtype="tool_call",
                 ))
             trace.append(compat["trace_event"](
@@ -575,8 +603,18 @@ class PiRuntimeAdapter:
                     "provider": "pi", "model": turn["model"],
                     "day": time.strftime("%Y-%m-%d", time.localtime(turn["end"])),
                     "ts": turn["end"], "start_ts": turn["start"], "duration_s": duration,
-                    "tool_calls": len(tools), "output_tokens": usage["output_tokens"],
-                    "context_tokens": context_tokens, "model_calls": 1, "timing_basis": "inferred",
+                    "generation_s": duration, "ttft_s": 0.0,
+                    "tool_calls": len(tools), "model_calls": 1,
+                    "output_tokens": usage["output_tokens"],
+                    "input_tokens": (usage["input_tokens"]
+                                     + usage["cache_read_input_tokens"]
+                                     + usage["cache_creation_input_tokens"]),
+                    "uncached_input_tokens": usage["input_tokens"],
+                    "cache_read_tokens": usage["cache_read_input_tokens"],
+                    "cache_write_tokens": usage["cache_creation_input_tokens"],
+                    "peak_input_tokens": turn["context_tokens"],
+                    "context_tokens": turn["context_tokens"],
+                    "timing_basis": "inferred",
                 })
         total_tokens, total_cost = sum(tot.values()), sum(cost.values())
         tool_data = compat["tool_summary"](executions)
@@ -587,10 +625,13 @@ class PiRuntimeAdapter:
         active = merge_execution_intervals(intervals)
         source = dict(source)
         source["context_latest"] = executions[-1]["context_tokens"] if executions else 0
+        throughput = performance_summary(wait_samples, tot["output"])
+        context_available = bool(turns) and all(turn["context_available"] for turn in turns)
         availability = compat["metric_availability"](
             "pi", cost=all_cost_available, tokens=all_tokens_available,
             input_tokens=all_tokens_available, output_tokens=all_tokens_available,
-            cache=all_cache_available, throughput=False, context=False, timing=bool(intervals),
+            cache=all_cache_available, throughput=throughput["available"],
+            context=context_available, timing=bool(intervals),
             tool_results=any(tool.get("result_available") for execution in executions for tool in execution["tools"]),
         )
         biggest = max(
@@ -610,6 +651,7 @@ class PiRuntimeAdapter:
              "basis": "inferred"},
             wait_samples, availability=availability,
         )
+        state["throughput"] = throughput
         state["semantic_available"] = False
         return state
 
@@ -620,13 +662,14 @@ class PiRuntimeAdapter:
         model_cost, model_tok, model_stats, model_daily = (
             defaultdict(float), defaultdict(int), {}, {}
         )
-        day_cost, tool_calls, intervals, models, wait_samples = (
-            defaultdict(float), [], [], set(), []
+        day_cost, tool_calls, intervals, models, wait_samples, context_samples = (
+            defaultdict(float), [], [], set(), [], []
         )
         total_cost = input_tokens = output_tokens = 0
         all_tokens_available = bool(turns) and all(turn["token_available"] for turn in turns)
         all_cache_available = bool(turns) and all(turn["cache_available"] for turn in turns)
         all_cost_available = bool(turns) and all(turn["cost"] is not None for turn in turns)
+        all_context_available = bool(turns) and all(turn["context_available"] for turn in turns)
         for turn in turns:
             usage = self._legacy_usage(turn)
             breakdown = turn["cost"] or {"input": 0.0, "cache_write": 0.0, "cache_read": 0.0, "output": 0.0}
@@ -646,26 +689,37 @@ class PiRuntimeAdapter:
                 day_cost[time.strftime("%Y-%m-%d", time.localtime(turn["end"]))] += value
             if turn["start"] and turn["end"] >= turn["start"]:
                 intervals.append((turn["start"], turn["end"]))
+                duration = turn["end"] - turn["start"]
+                context_samples.append(turn["context_tokens"])
                 wait_samples.append({
                     "provider": "pi", "model": turn["model"],
                     "day": time.strftime("%Y-%m-%d", time.localtime(turn["end"])),
                     "ts": turn["end"], "start_ts": turn["start"],
-                    "duration_s": turn["end"] - turn["start"],
-                    "tool_calls": len(turn["tools"]),
+                    "duration_s": duration, "generation_s": duration, "ttft_s": 0.0,
+                    "tool_calls": len(turn["tools"]), "model_calls": 1,
                     "output_tokens": usage["output_tokens"],
-                    "context_tokens": 0, "model_calls": 1,
+                    "input_tokens": (usage["input_tokens"]
+                                     + usage["cache_read_input_tokens"]
+                                     + usage["cache_creation_input_tokens"]),
+                    "uncached_input_tokens": usage["input_tokens"],
+                    "cache_read_tokens": usage["cache_read_input_tokens"],
+                    "cache_write_tokens": usage["cache_creation_input_tokens"],
+                    "peak_input_tokens": turn["context_tokens"],
+                    "context_tokens": turn["context_tokens"],
                     "timing_basis": "inferred",
                 })
             for tool in turn["tools"]:
                 tool_calls.append({
                     "name": tool["name"], "display": tool["name"].replace("_", " ").title(),
                     "namespace": tool["category"], "kind": "tool", "output_tokens": 0,
-                    "error": False, "ts": turn["end"], "skills": [],
+                    "error": bool(tool.get("error")), "ts": turn["end"], "skills": [],
                 })
+        throughput = performance_summary(wait_samples, output_tokens)
         availability = compat["metric_availability"](
             "pi", cost=all_cost_available, tokens=all_tokens_available,
             input_tokens=all_tokens_available, output_tokens=all_tokens_available,
-            cache=all_cache_available, throughput=False, context=False, timing=bool(intervals),
+            cache=all_cache_available, throughput=throughput["available"],
+            context=all_context_available, timing=bool(intervals),
             tool_results=False,
         )
         for stats in (*model_stats.values(), *model_daily.values()):
@@ -673,7 +727,8 @@ class PiRuntimeAdapter:
                 "pi", cost=int(stats.get("cost_covered_executions") or 0) > 0,
                 tokens=all_tokens_available, input_tokens=all_tokens_available,
                 output_tokens=all_tokens_available, cache=all_cache_available,
-                throughput=False, context=False, timing=False, tool_results=False,
+                throughput=throughput["available"], context=all_context_available,
+                timing=False, tool_results=False,
             )
         row = compat["summary_row"](
             source, None, total_cost, sum(model_tok.values()), len(turns), models,
@@ -682,11 +737,14 @@ class PiRuntimeAdapter:
             model_cost, model_tok, day_cost, True,
             {"duration_s": merge_execution_intervals(intervals), "available": bool(intervals),
              "basis": "inferred"}, input_tokens, output_tokens, model_stats,
-            list(model_daily.values()), [], wait_samples, availability,
+            list(model_daily.values()), wait_samples, wait_samples, availability,
         )
         row["primary_model"] = max(model_tok, key=model_tok.get) if model_tok else source.get("model")
-        row["context"] = {"latest": 0, "window": None, "latest_pct": None, "estimated": False}
-        row["_context_samples"] = []
+        row["context"] = {
+            "latest": context_samples[-1] if context_samples else 0,
+            "window": None, "latest_pct": None, "estimated": False,
+        }
+        row["_context_samples"] = context_samples[-compat["context_sample_limit"]:]
         row["terminal"] = False
         row["_tool_evidence"] = compat["summarize_tool_evidence"](tool_calls)
         return row


### PR DESCRIPTION
## Summary

While testing Pi runtime support against live traces, four Pi projections were found to under-report evidence that Pi records but the adapter did not project. This PR fixes all four in the Pi adapter plus its compat wiring, with tests.

1. **Tool errors reported as successes.** Pi `toolResult` rows carry `isError`, present in real traces, but the adapter hardcoded `error: False` and marked any completed call `"success"`. Errored calls now surface in tool error counts, tool status (`"error"`), and warn-severity trace events.
2. **Reasoning breakdown dropped.** Pi records `usage.reasoning` as a subset of the output bucket (confirmed against Pi's own `openai-completions` and `google` provider chunks). The adapter now clamps the reported subset to output tokens and feeds the reasoning split to series and executions, matching the Claude and Codex adapters. Totals are unchanged.
3. **Context in use unavailable.** The latest turn's `input + cacheRead + cacheWrite` is the same request-usage basis Claude projects for "Context in use"; the adapter hardcoded zero. The Pi card now shows measured context tokens with the window remaining unknown, exactly like Claude (`52K WINDOW --`).
4. **Output pace unavailable.** The user-to-assistant wall clock excludes human pause by construction (the turn starts at the user message timestamp), qualifying Pi for the `end_to_end` diagnostic basis the dashboard already labels for Claude. TTFT stays unavailable.

Unavailable projections (context window size, TTFT, semantic token split, cache-savings price) still remain unavailable rather than becoming derived or reported zeroes. `specs/ARCHITECTURE.md` documents the corrected Pi boundary.

## Changes

- `token_meter/runtimes/pi.py`: error propagation from `isError`, reasoning subset projection, per-turn context tokens, shared performance/wait sample schema, `performance_summary` throughput, availability flags
- `token_meter/app.py`: expose `context_sample_limit` to the Pi compatibility layer
- `tests/test_meter.py`: new `PiRuntimeTests` for tool error status (success kept clean), reasoning clamping, context/pace availability, and the no-usage case
- `specs/ARCHITECTURE.md`: corrected Pi evidence paragraph

## Validation

- `python3 -m unittest discover -s tests`: 787 tests, 16 skipped, OK
- `py_compile` over `meter.py`, `token_meter_mcp.py`, and the `token_meter` tree: clean
- `git diff --check`: clean
- Live verification against real Pi session traces: totals match raw JSONL exactly; previously silenced errored tool calls and reasoning tokens now surface; the current-session card reports context in use and end-to-end tok/s; `/health` and `/menubar` valid with Pi sources discovered and no adapter failures
