### PR TITLE
Fix Git delivery watcher interval floor

### DIFF
--- a/tests/test_git_delivery.py
+++ b/tests/test_git_delivery.py
@@ -663,6 +663,52 @@ class GitDeliveryApplicationTests(unittest.TestCase):
         service.clear.assert_called_once_with()
         wake.set.assert_called_once_with()
 
+    def test_watcher_floors_repeated_wakes_after_a_prompt_ready_scan(self):
+        service = mock.Mock()
+        service.scan.side_effect = [None, RuntimeError("stop watcher")]
+        wake = mock.Mock()
+        wake.wait.return_value = True
+        first_sources = ({"project": "/repo/first"},)
+        latest_sources = ({"project": "/repo/latest"},)
+        inventory = {"ready": True, "sources": first_sources}
+
+        def release_floor(seconds):
+            self.assertEqual(seconds, meter.GIT_DELIVERY_INTERVAL_S)
+            inventory["sources"] = latest_sources
+
+        with (mock.patch.object(meter, "_SOURCE_INVENTORY", inventory),
+              mock.patch.object(meter, "_git_delivery_wake", wake),
+              mock.patch.object(
+                  meter, "git_delivery_candidates",
+                  side_effect=[
+                      [{"root": "/repo/first"}],
+                      [{"root": "/repo/latest"}],
+                  ],
+              ) as candidates,
+              mock.patch.object(meter, "git_delivery_service", return_value=service),
+              mock.patch.object(
+                  meter.time, "monotonic", side_effect=[0.0, 0.0, 0.0, 300.0],
+              ),
+              mock.patch.object(
+                  meter.time, "sleep", side_effect=release_floor,
+              ) as sleep):
+            with self.assertRaisesRegex(RuntimeError, "stop watcher"):
+                meter.git_delivery_watcher()
+
+        self.assertEqual(
+            service.scan.call_args_list,
+            [
+                mock.call([{"root": "/repo/first"}]),
+                mock.call([{"root": "/repo/latest"}]),
+            ],
+        )
+        self.assertEqual(
+            candidates.call_args_list,
+            [mock.call(first_sources), mock.call(latest_sources)],
+        )
+        sleep.assert_called_once_with(meter.GIT_DELIVERY_INTERVAL_S)
+        wake.wait.assert_not_called()
+
     def test_spend_rows_keep_uncovered_cost_explicit(self):
         rows = meter.delivery_spend_rows([
             {"project": "/repo", "availability": {"cost": True},

--- a/token_meter/app.py
+++ b/token_meter/app.py
@@ -7080,15 +7080,20 @@ def clear_git_delivery_activity(confirm=False):
 
 def git_delivery_watcher():
     """Inspect local successful-push reflogs every five minutes."""
+    next_scan_at = 0.0
     while True:
         if not _SOURCE_INVENTORY.get("ready"):
             _git_delivery_wake.wait(1.0)
             _git_delivery_wake.clear()
             continue
+        remaining = next_scan_at - time.monotonic()
+        if remaining > 0:
+            _git_delivery_wake.clear()
+            time.sleep(remaining)
+            continue
         candidates = git_delivery_candidates(_SOURCE_INVENTORY.get("sources") or ())
         git_delivery_service().scan(candidates)
-        _git_delivery_wake.wait(GIT_DELIVERY_INTERVAL_S)
-        _git_delivery_wake.clear()
+        next_scan_at = time.monotonic() + GIT_DELIVERY_INTERVAL_S
 
 
 def aggregate_model_stats(session_rows):


### PR DESCRIPTION
## Summary
- enforce the configured five-minute floor after each completed Git delivery scan
- coalesce repeated source-inventory wake signals and scan the latest inventory after the floor
- add a deterministic regression test for the back-to-back scan reported in #30

Closes #30

## Validation
- regression test observed the old back-to-back failure before the production change
- `python3 -m unittest tests.test_git_delivery -v` — 58 passed
- Python compile and `git diff --check` passed
- `./scripts/install`, runtime-manifest parity, `/health`, `/menubar`, and both macOS LaunchAgents passed
- independent Token Meter review found no actionable issues

The full suite ran 912 tests: 894 passed, 16 skipped, and 2 unrelated baseline/environment checks failed (`docs/.DS_Store` in the local Pages inventory and pre-existing README Pi wording).

## Still to verify
- reporter-scale CPU and Git subprocess frequency under roughly 20 concurrent sessions, 100 repositories, and 200 worktrees
- Linux and Windows target-host behavior