### PR TITLE
Add a desktop usage widget and Grok account quotas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,20 @@ DerivedData/
 .idea/
 .vscode/
 
+# Secrets and personal machine state
+*.pem
+*.p12
+*.pfx
+id_rsa
+id_rsa.pub
+id_ed25519
+id_ed25519.pub
+auth.json
+.credentials.json
+chrome-profile/
+/.token-meter/
+/.grok/
+
 # Local agent planning state, not public user docs
 PLAN.md
 /plan.md

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 Token Meter is a local-first observability dashboard for AI coding agents. It
-turns session evidence from Claude, Codex, Cursor, OpenCode, Kiro, and Pi into one
+turns session evidence from Claude, Codex, Cursor, OpenCode, Kiro, Pi, Hermes, and Grok into one
 view of what happened, what it cost, and where time went—so you can decide
 whether to continue, intervene, compare, or investigate a run.
 
@@ -64,7 +64,7 @@ troubleshooting, see the [User guide](specs/USER_GUIDE.md).
 ## Coverage
 
 **Runtimes:** Claude Code and Desktop Agent/Cowork, Codex CLI and desktop,
-Cursor Agent/Composer, OpenCode, Kiro, and Pi.
+Cursor Agent/Composer, OpenCode, Kiro, Pi, Hermes, and Grok Build.
 
 | Platform | Status | Experience |
 | --- | --- | --- |

--- a/menubar/TokenMeterMenuBar.swift
+++ b/menubar/TokenMeterMenuBar.swift
@@ -2298,8 +2298,8 @@ final class TokenMeterMenuBar: NSObject, NSApplicationDelegate, NSMenuDelegate {
         if ProcessInfo.processInfo.environment["TOKEN_METER_MENUBAR_SMOKE"] == "1" { return }
         if usageWidgetWindow == nil {
             usageWidgetWindow = makeUsageWidgetPanel()
+            positionUsageWidget()
         }
-        positionUsageWidget()
         usageWidgetWindow?.makeKeyAndOrderFront(nil)
     }
 
@@ -2315,6 +2315,8 @@ final class TokenMeterMenuBar: NSObject, NSApplicationDelegate, NSMenuDelegate {
         NSApp.activate(ignoringOtherApps: true)
     }
 
+    private var usageWidgetSnapWork: DispatchWorkItem?
+
     private func makeUsageWidgetPanel() -> NSPanel {
         let panel = NSPanel(
             contentRect: NSRect(x: 0, y: 0, width: 300, height: 520),
@@ -2327,12 +2329,44 @@ final class TokenMeterMenuBar: NSObject, NSApplicationDelegate, NSMenuDelegate {
         panel.level = .floating
         panel.hidesOnDeactivate = false
         panel.isReleasedWhenClosed = false
+        panel.isMovableByWindowBackground = true
         panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
         let webView = WKWebView(frame: panel.contentView?.bounds ?? .zero)
         webView.autoresizingMask = [.width, .height]
         webView.load(URLRequest(url: tokenMeterWidgetURL))
         panel.contentView = webView
+        NotificationCenter.default.addObserver(
+            forName: NSWindow.didMoveNotification,
+            object: panel,
+            queue: .main
+        ) { [weak self] _ in
+            self?.scheduleUsageWidgetSnap()
+        }
         return panel
+    }
+
+    private func screenContaining(point: NSPoint) -> NSScreen? {
+        NSScreen.screens.first { NSMouseInRect(point, $0.frame, false) } ?? NSScreen.main
+    }
+
+    private func snapUsageWidget() {
+        guard let panel = usageWidgetWindow, let screen = screenContaining(point: NSPoint(x: panel.frame.midX, y: panel.frame.midY)) else { return }
+        var frame = panel.frame
+        let work = screen.visibleFrame
+        if frame.midX >= work.midX {
+            frame.origin.x = work.maxX - frame.width - 12
+        } else {
+            frame.origin.x = work.minX + 12
+        }
+        frame.origin.y = min(max(frame.origin.y, work.minY), work.maxY - frame.height)
+        panel.setFrame(frame, display: true)
+    }
+
+    private func scheduleUsageWidgetSnap() {
+        usageWidgetSnapWork?.cancel()
+        let work = DispatchWorkItem { [weak self] in self?.snapUsageWidget() }
+        usageWidgetSnapWork = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.12, execute: work)
     }
 
     private func positionUsageWidget() {

--- a/menubar/TokenMeterMenuBar.swift
+++ b/menubar/TokenMeterMenuBar.swift
@@ -1,9 +1,11 @@
 import Cocoa
 import Carbon.HIToolbox
 import Foundation
+import WebKit
 
 private let tokenMeterMenubarURL = URL(string: "http://127.0.0.1:8722/menubar")!
 private let tokenMeterDashboardURL = URL(string: "http://127.0.0.1:8722/#sessions")!
+private let tokenMeterWidgetURL = URL(string: "http://127.0.0.1:8722/#widget")!
 private let tokenMeterBudgetSettingsURL = URL(string: "http://127.0.0.1:8722/#settings-budgets")!
 private let tokenMeterUpdateSettingsURL = URL(string: "http://127.0.0.1:8722/#settings-updates")!
 private let tokenMeterInstallUpdateURL = URL(string: "http://127.0.0.1:8722/updates/install")!
@@ -22,6 +24,7 @@ private let globalShortcutDefaultsKey = "TokenMeterGlobalShortcut"
 private let customShortcutKeyCodeDefaultsKey = "TokenMeterCustomShortcutKeyCode"
 private let customShortcutModifiersDefaultsKey = "TokenMeterCustomShortcutModifiers"
 private let tokenMeterMenubarBundleIdentifier = "com.token-meter.menubar"
+private let usageWidgetOpenDefaultsKey = "TokenMeterUsageWidgetOpen"
 private let statusItemAutosaveName = "TokenMeterPrimaryStatusItem"
 private let statusItemPreferredPositionDefaultsKey = "NSStatusItem Preferred Position \(statusItemAutosaveName)"
 private let statusItemInitialPreferredPosition = 50
@@ -1077,6 +1080,7 @@ final class TokenMeterMenuBar: NSObject, NSApplicationDelegate, NSMenuDelegate {
     private var snapshot = MeterSnapshot.disconnected("Waiting for http://127.0.0.1:8722/menubar")
     private var monthlyBudget: MonthlyBudget?
     private var softwareUpdate = SoftwareUpdateSnapshot.waiting
+    private var usageWidgetWindow: NSPanel?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSApp.setActivationPolicy(.accessory)
@@ -1095,6 +1099,9 @@ final class TokenMeterMenuBar: NSObject, NSApplicationDelegate, NSMenuDelegate {
         registerGlobalHotKey()
         rebuildMenu()
         fetchState()
+        if usageWidgetOpenPreference {
+            showUsageWidget()
+        }
         timer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { [weak self] _ in
             self?.fetchState()
         }
@@ -1217,6 +1224,11 @@ final class TokenMeterMenuBar: NSObject, NSApplicationDelegate, NSMenuDelegate {
         if !snapshot.connected {
             addConnectionRow()
         }
+
+        let widgetItem = NSMenuItem(title: "Usage widget", action: #selector(toggleUsageWidget), keyEquivalent: "")
+        widgetItem.image = menuSymbol("rectangle.trailinghalf.inset.filled", description: "Usage widget")
+        widgetItem.target = self
+        menu.addItem(widgetItem)
 
         let limitsItem = NSMenuItem(title: "Provider limits (Beta)", action: nil, keyEquivalent: "")
         limitsItem.image = menuSymbol("gauge.with.dots.needle.50percent", description: "Provider limits (Beta)")
@@ -2272,6 +2284,63 @@ final class TokenMeterMenuBar: NSObject, NSApplicationDelegate, NSMenuDelegate {
             "--", title, body,
         ]
         try? process.run()
+    }
+
+    private var usageWidgetOpenPreference: Bool {
+        get {
+            if tokenMeterDefaults.object(forKey: usageWidgetOpenDefaultsKey) == nil { return true }
+            return tokenMeterDefaults.bool(forKey: usageWidgetOpenDefaultsKey)
+        }
+        set { tokenMeterDefaults.set(newValue, forKey: usageWidgetOpenDefaultsKey) }
+    }
+
+    private func showUsageWidget() {
+        if ProcessInfo.processInfo.environment["TOKEN_METER_MENUBAR_SMOKE"] == "1" { return }
+        if usageWidgetWindow == nil {
+            usageWidgetWindow = makeUsageWidgetPanel()
+        }
+        positionUsageWidget()
+        usageWidgetWindow?.makeKeyAndOrderFront(nil)
+    }
+
+    @objc private func toggleUsageWidget() {
+        if ProcessInfo.processInfo.environment["TOKEN_METER_MENUBAR_SMOKE"] == "1" { return }
+        if usageWidgetWindow?.isVisible == true {
+            usageWidgetWindow?.orderOut(nil)
+            usageWidgetOpenPreference = false
+            return
+        }
+        usageWidgetOpenPreference = true
+        showUsageWidget()
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    private func makeUsageWidgetPanel() -> NSPanel {
+        let panel = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 300, height: 520),
+            styleMask: [.titled, .closable, .utilityWindow, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.title = "Token Meter"
+        panel.isFloatingPanel = true
+        panel.level = .floating
+        panel.hidesOnDeactivate = false
+        panel.isReleasedWhenClosed = false
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        let webView = WKWebView(frame: panel.contentView?.bounds ?? .zero)
+        webView.autoresizingMask = [.width, .height]
+        webView.load(URLRequest(url: tokenMeterWidgetURL))
+        panel.contentView = webView
+        return panel
+    }
+
+    private func positionUsageWidget() {
+        guard let panel = usageWidgetWindow, let screen = NSScreen.main else { return }
+        var frame = panel.frame
+        frame.origin.x = screen.visibleFrame.maxX - frame.width - 12
+        frame.origin.y = screen.visibleFrame.maxY - frame.height - 72
+        panel.setFrame(frame, display: true)
     }
 
     @objc private func openDashboard() {

--- a/menubar/token_meter_tray.py
+++ b/menubar/token_meter_tray.py
@@ -2,6 +2,7 @@
 """Linux StatusNotifier/AppIndicator companion for Token Meter."""
 import json
 import os
+import signal
 import subprocess
 import sys
 import time
@@ -22,6 +23,7 @@ MENU_TABS = (
     ("claude", "Claude"),
     ("codex", "Codex"),
     ("cursor", "Cursor"),
+    ("grok", "Grok"),
 )
 TITLE_METRICS = (
     ("cost", "Cost"),
@@ -41,7 +43,9 @@ DEFAULT_STATE = {
     "quota_notification_states": {},
     "budget_notification_states": {},
     "budget_exceeded_notification_months": [],
+    "usage_widget_open": True,
 }
+WIDGET_APPLICATION_ID = "com.tokenmeter.usagewidget"
 
 
 def metric_available(availability, metric):
@@ -588,11 +592,89 @@ try:
     except (ValueError, ImportError):
         gi.require_version("AppIndicator3", "0.1")
         from gi.repository import AppIndicator3 as AppIndicator
-    from gi.repository import GLib, Gtk
+    from gi.repository import Gio, GLib, Gtk
     GTK_AVAILABLE = True
 except (ImportError, ValueError):
     AppIndicator = None
-    GLib = Gtk = None
+    GLib = Gtk = Gio = None
+
+
+def usage_widget_script():
+    return os.path.join(os.path.dirname(os.path.abspath(__file__)), "token_meter_widget.py")
+
+
+def _dbus_session_call(method, params, reply_type):
+    bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+    return bus.call_sync(
+        "org.freedesktop.DBus",
+        "/org/freedesktop/DBus",
+        "org.freedesktop.DBus",
+        method,
+        params,
+        reply_type,
+        Gio.DBusCallFlags.NONE,
+        500,
+        None,
+    )
+
+
+def usage_widget_running():
+    if Gio is None or GLib is None:
+        return False
+    try:
+        reply = _dbus_session_call(
+            "NameHasOwner",
+            GLib.Variant("(s)", (WIDGET_APPLICATION_ID,)),
+            GLib.VariantType("(b)"),
+        )
+        return bool(reply.unpack()[0])
+    except Exception:
+        return False
+
+
+def usage_widget_pid():
+    if Gio is None or GLib is None:
+        return None
+    try:
+        reply = _dbus_session_call(
+            "GetConnectionUnixProcessID",
+            GLib.Variant("(s)", (WIDGET_APPLICATION_ID,)),
+            GLib.VariantType("(u)"),
+        )
+        return int(reply.unpack()[0])
+    except Exception:
+        return None
+
+
+def spawn_usage_widget(args=None):
+    """Start, raise, or stop the separate desktop widget process. Never embed it here."""
+    if os.environ.get("TOKEN_METER_TRAY_SMOKE") == "1":
+        return
+    if args and "--quit" in args:
+        pid = usage_widget_pid()
+        if pid:
+            try:
+                os.kill(pid, signal.SIGTERM)
+            except OSError:
+                pass
+        return
+    env = os.environ.copy()
+    if (
+        env.get("XDG_SESSION_TYPE") == "wayland"
+        and env.get("DISPLAY")
+        and not env.get("GDK_BACKEND")
+    ):
+        env["GDK_BACKEND"] = "x11"
+    try:
+        subprocess.Popen(
+            [sys.executable, usage_widget_script()],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+            env=env,
+        )
+    except OSError as exc:
+        print(f"Token Meter could not open the usage widget: {exc}", file=sys.stderr)
 
 
 def gtk_requirements_message():
@@ -617,6 +699,7 @@ class TokenMeterTray:
         self.quota_observation_established = bool(
             self.settings.get("quota_observation_established")
         )
+        self.usage_widget_open = bool(self.settings.get("usage_widget_open", True))
         self.snapshot = {}
         self.monthly_budget = None
         self.provider_quotas = []
@@ -687,6 +770,8 @@ class TokenMeterTray:
                 "pace": self._metric_item(""),
             })
         self.actions_separator = Gtk.SeparatorMenuItem()
+        self.usage_widget_item = Gtk.CheckMenuItem(label="Usage widget")
+        self.usage_widget_item.connect("toggled", self._on_usage_widget_toggled)
         self.action_items = {
             "Open Dashboard": self._action_item(
                 "Open Dashboard", lambda *_: self.open_dashboard(),
@@ -742,6 +827,8 @@ class TokenMeterTray:
         self.indicator.set_menu(self.menu)
         self.poll()
         GLib.timeout_add_seconds(2, self.poll)
+        if self.usage_widget_open:
+            GLib.idle_add(self._start_usage_widget)
 
     def _submenu_item(self, label):
         item = Gtk.MenuItem(label=label)
@@ -785,6 +872,7 @@ class TokenMeterTray:
         self.menu.append(self.provider_detail_items["coverage"])
         self.menu.append(self.provider_detail_items["footer"])
         self.menu.append(self.actions_separator)
+        self.menu.append(self.usage_widget_item)
         for item in self.action_items.values():
             self.menu.append(item)
         self.menu.append(self.settings_item)
@@ -801,6 +889,7 @@ class TokenMeterTray:
 
     def _on_menu_show(self, _menu):
         self.menu_open = True
+        self._sync_usage_widget_item()
 
     def _on_menu_hide(self, _menu):
         self.menu_open = False
@@ -838,6 +927,7 @@ class TokenMeterTray:
                 self.settings.get("budget_exceeded_notification_months") or []
             ),
             "quota_observation_established": self.quota_observation_established,
+            "usage_widget_open": self.usage_widget_open,
         }
         try:
             os.makedirs(os.path.dirname(STATE_PATH), mode=0o700, exist_ok=True)
@@ -961,6 +1051,29 @@ class TokenMeterTray:
     def _on_quota_alerts_toggled(self, item):
         self.quota_alerts_enabled = item.get_active()
         self.save_state()
+
+    def _sync_usage_widget_item(self):
+        if usage_widget_running():
+            self.usage_widget_open = True
+        if self.usage_widget_item.get_active() != bool(self.usage_widget_open):
+            self.usage_widget_item.handler_block_by_func(self._on_usage_widget_toggled)
+            self.usage_widget_item.set_active(bool(self.usage_widget_open))
+            self.usage_widget_item.handler_unblock_by_func(self._on_usage_widget_toggled)
+
+    def _start_usage_widget(self):
+        if self.usage_widget_open:
+            spawn_usage_widget()
+        return False
+
+    def _on_usage_widget_toggled(self, item):
+        want = bool(item.get_active())
+        self.usage_widget_open = want
+        self.save_state()
+        running = usage_widget_running()
+        if want and not running:
+            spawn_usage_widget()
+        elif not want and running:
+            spawn_usage_widget(["--quit"])
         self.refresh_menu_content()
 
     def _on_threshold_toggled(self, item):
@@ -1014,6 +1127,7 @@ class TokenMeterTray:
         for tab_id, item in self.tab_items.items():
             item.set_active(tab_id == self.selected_tab)
         self.quota_alerts_item.set_active(self.quota_alerts_enabled)
+        self._sync_usage_widget_item()
         for threshold, item in self.threshold_items.items():
             item.set_active(threshold == self.quota_alert_threshold)
         for metric_id, item in self.title_metric_items.items():

--- a/menubar/token_meter_tray.py
+++ b/menubar/token_meter_tray.py
@@ -669,12 +669,13 @@ def spawn_usage_widget(args=None):
         subprocess.Popen(
             [sys.executable, usage_widget_script()],
             stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
             start_new_session=True,
             env=env,
         )
+        return True
     except OSError as exc:
         print(f"Token Meter could not open the usage widget: {exc}", file=sys.stderr)
+        return False
 
 
 def gtk_requirements_message():
@@ -1053,16 +1054,35 @@ class TokenMeterTray:
         self.save_state()
 
     def _sync_usage_widget_item(self):
-        if usage_widget_running():
+        running = usage_widget_running()
+        if running:
             self.usage_widget_open = True
         if self.usage_widget_item.get_active() != bool(self.usage_widget_open):
             self.usage_widget_item.handler_block_by_func(self._on_usage_widget_toggled)
             self.usage_widget_item.set_active(bool(self.usage_widget_open))
             self.usage_widget_item.handler_unblock_by_func(self._on_usage_widget_toggled)
 
+    def _confirm_usage_widget_started(self):
+        if not self.usage_widget_open:
+            return False
+        if usage_widget_running():
+            return False
+        self.usage_widget_open = False
+        self.save_state()
+        self._sync_usage_widget_item()
+        print(
+            "Token Meter usage widget failed to start. "
+            "Install GTK 3 and PyGObject, then toggle Usage widget again.",
+            file=sys.stderr,
+        )
+        self.refresh_menu_content()
+        return False
+
     def _start_usage_widget(self):
         if self.usage_widget_open:
             spawn_usage_widget()
+            if GLib is not None:
+                GLib.timeout_add(600, self._confirm_usage_widget_started)
         return False
 
     def _on_usage_widget_toggled(self, item):
@@ -1072,6 +1092,8 @@ class TokenMeterTray:
         running = usage_widget_running()
         if want and not running:
             spawn_usage_widget()
+            if GLib is not None:
+                GLib.timeout_add(600, self._confirm_usage_widget_started)
         elif not want and running:
             spawn_usage_widget(["--quit"])
         self.refresh_menu_content()

--- a/menubar/token_meter_widget.py
+++ b/menubar/token_meter_widget.py
@@ -1,0 +1,887 @@
+#!/usr/bin/env python3
+"""Native Linux desktop usage widget for Token Meter.
+
+Runs as a separate GTK process from the AppIndicator tray so an overlay
+window cannot take down the tray (or systemd Restart=on-failure).
+"""
+import json
+import os
+import subprocess
+import sys
+from urllib.error import URLError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+BASE_URL = os.environ.get("TOKEN_METER_URL", "http://127.0.0.1:8722").rstrip("/")
+STATE_URL = BASE_URL + "/menubar"
+APPLICATION_ID = "com.tokenmeter.usagewidget"
+UNKNOWN_RUNTIME = "unknown-runtime"
+POLL_SECONDS = 4
+COLLAPSED_SIZE = (36, 168)
+EXPANDED_SIZE = (300, 520)
+PANEL_MARGIN_X = 12
+DEFAULT_TOP = 96
+DRAG_THRESHOLD = 6
+
+GTK_AVAILABLE = False
+Gdk = GLib = Gtk = Gio = None
+
+
+def usage_widget_chips(payload):
+    catalog = payload.get("runtime_catalog") if isinstance(payload, dict) else None
+    if not isinstance(catalog, dict):
+        catalog = {}
+    quotas = payload.get("provider_quotas") if isinstance(payload, dict) else None
+    sessions = payload.get("recent_sessions") if isinstance(payload, dict) else None
+    chips = []
+    seen = set()
+
+    def add(provider_id, label=None):
+        provider_id = str(provider_id or "")
+        if not provider_id or provider_id == UNKNOWN_RUNTIME or provider_id in seen:
+            return
+        seen.add(provider_id)
+        meta = catalog.get(provider_id) if isinstance(catalog.get(provider_id), dict) else {}
+        chips.append({
+            "id": provider_id,
+            "label": str(meta.get("label") or label or provider_id),
+            "has_quota": False,
+        })
+
+    for row in quotas or ():
+        if isinstance(row, dict):
+            add(row.get("id"), row.get("label"))
+    for row in sessions or ():
+        if isinstance(row, dict):
+            add(row.get("provider"), row.get("label"))
+    quota_ids = {
+        str(row.get("id") or "")
+        for row in (quotas or ())
+        if isinstance(row, dict)
+    }
+    for chip in chips:
+        chip["has_quota"] = chip["id"] in quota_ids
+    return chips
+
+
+def _quota_windows(row):
+    windows = row.get("windows") if isinstance(row, dict) else None
+    return [window for window in (windows or ()) if isinstance(window, dict)]
+
+
+def _hottest_percent(windows):
+    hottest = None
+    for window in windows:
+        used = window.get("used_percent")
+        if used is None:
+            continue
+        try:
+            used = float(used)
+        except (TypeError, ValueError):
+            continue
+        if hottest is None or used > hottest:
+            hottest = used
+    return hottest
+
+
+def _primary_quota(quotas):
+    ranked = []
+    for row in quotas:
+        windows = _quota_windows(row)
+        if not windows:
+            continue
+        ranked.append(( _hottest_percent(windows) or -1, row, windows))
+    if not ranked:
+        return None, []
+    ranked.sort(key=lambda item: item[0], reverse=True)
+    return ranked[0][1], ranked[0][2]
+
+
+def _chip_label(chips, provider_id, payload):
+    for chip in chips:
+        if chip["id"] == provider_id:
+            return chip["label"]
+    source = payload.get("source") if isinstance(payload.get("source"), dict) else {}
+    return str(source.get("label") or "Token Meter")
+
+
+def usage_widget_view(payload, selected_id=""):
+    payload = payload if isinstance(payload, dict) else {}
+    chips = usage_widget_chips(payload)
+    selected_id = str(selected_id or "")
+    known = {chip["id"] for chip in chips}
+    if selected_id not in known:
+        selected_id = ""
+    quotas = [
+        row for row in (payload.get("provider_quotas") or ())
+        if isinstance(row, dict)
+    ]
+    sessions = [
+        row for row in (payload.get("recent_sessions") or ())
+        if isinstance(row, dict)
+    ]
+    if selected_id:
+        quotas = [row for row in quotas if str(row.get("id") or "") == selected_id]
+        sessions = [row for row in sessions if str(row.get("provider") or "") == selected_id]
+        primary = quotas[0] if quotas else None
+        windows = _quota_windows(primary) if primary else []
+        title = _chip_label(chips, selected_id, payload)
+    else:
+        primary, windows = _primary_quota(quotas)
+        title = (primary or {}).get("label") or _chip_label(
+            chips, str((primary or {}).get("id") or ""), payload,
+        )
+        if not primary:
+            title = str((payload.get("source") or {}).get("label") or "Token Meter")
+    live = payload.get("live_throughput") if isinstance(payload.get("live_throughput"), dict) else {}
+    current_provider = str(payload.get("provider") or "")
+    live_ok = bool(live.get("available")) and (
+        not selected_id or current_provider == selected_id
+    )
+    try:
+        live_tps = float(live.get("output_tps") or 0) if live_ok else None
+    except (TypeError, ValueError):
+        live_tps = None
+    if live_tps is not None and live_tps <= 0:
+        live_tps = None
+    return {
+        "chips": chips,
+        "selected_id": selected_id,
+        "title": title,
+        "windows": windows,
+        "sessions": sessions[:5],
+        "hottest": _hottest_percent(windows),
+        "quota_available": bool(windows),
+        "live_tps": live_tps,
+        "ended": bool(payload.get("ended")),
+    }
+
+
+def fetch_menubar():
+    request = Request(STATE_URL, headers={"Cache-Control": "no-cache", "Pragma": "no-cache"})
+    with urlopen(request, timeout=5) as response:
+        if response.status != 200:
+            raise URLError(f"HTTP {response.status}")
+        payload = json.load(response)
+    if not isinstance(payload, dict):
+        raise ValueError("unreadable response")
+    return payload
+
+
+def session_url(session_id):
+    return f"{BASE_URL}/sessions/{quote(str(session_id or ''), safe='')}#summary"
+
+
+def compact_number(value):
+    value = float(value or 0)
+    magnitude = abs(value)
+    if magnitude >= 1_000_000:
+        text = f"{value / 1_000_000:.1f}".rstrip("0").rstrip(".")
+        return text + "M"
+    if magnitude >= 1_000:
+        text = f"{value / 1_000:.1f}".rstrip("0").rstrip(".")
+        return text + "K"
+    if magnitude >= 10:
+        return f"{value:.0f}"
+    return f"{value:.1f}".rstrip("0").rstrip(".")
+
+
+def percent_label(value):
+    if value is None:
+        return "--"
+    return f"{float(value):.0f}%"
+
+
+def widget_state_path():
+    config_home = os.path.expanduser(os.environ.get("XDG_CONFIG_HOME") or "~/.config")
+    return os.path.join(config_home, "token-meter", "widget.json")
+
+
+def load_widget_position():
+    try:
+        with open(widget_state_path(), encoding="utf-8") as handle:
+            value = json.load(handle)
+    except (OSError, ValueError):
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def save_widget_position(payload):
+    path = widget_state_path()
+    try:
+        os.makedirs(os.path.dirname(path), mode=0o700, exist_ok=True)
+        temporary = path + ".tmp"
+        with open(temporary, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle)
+        os.chmod(temporary, 0o600)
+        os.replace(temporary, path)
+    except OSError:
+        pass
+
+
+def usage_widget_size(expanded):
+    if expanded:
+        return (
+            COLLAPSED_SIZE[0] + EXPANDED_SIZE[0] + 2 * PANEL_MARGIN_X,
+            max(EXPANDED_SIZE[1], 280),
+        )
+    return COLLAPSED_SIZE
+
+
+def usage_widget_anchor(x, width, monitor):
+    mx, _my, mw, _mh = monitor
+    midpoint = float(x) + float(width) / 2.0
+    return "right" if midpoint >= mx + mw / 2.0 else "left"
+
+
+def usage_widget_dock_x(anchor, width, monitor):
+    """X origin that keeps the drawn width flush with the docked wall."""
+    mx, _my, mw, _mh = [int(v) for v in (monitor or (0, 0, 1920, 1080))]
+    width = max(1, int(width or COLLAPSED_SIZE[0]))
+    if str(anchor) == "left":
+        return mx
+    return mx + mw - width
+
+
+def usage_widget_snap(x, y, width, height, monitor):
+    """Pin the drawer to the nearer left or right edge; keep the drop's Y."""
+    mx, my, mw, mh = [int(v) for v in (monitor or (0, 0, 1920, 1080))]
+    width = max(1, int(width or COLLAPSED_SIZE[0]))
+    height = max(1, int(height or COLLAPSED_SIZE[1]))
+    anchor = usage_widget_anchor(x, width, (mx, my, mw, mh))
+    snap_y = max(my, min(int(y), my + mh - min(height, mh)))
+    return {
+        "x": usage_widget_dock_x(anchor, width, (mx, my, mw, mh)),
+        "y": snap_y,
+        "width": width,
+        "height": height,
+        "anchor": anchor,
+    }
+
+
+def usage_widget_frame(expanded, position=None, monitor=None):
+    """Keep the docked wall flush; left opens rightward, right opens leftward."""
+    mx, my, mw, mh = monitor or (0, 0, 1920, 1080)
+    mx, my, mw, mh = int(mx), int(my), int(mw), int(mh)
+    width, height = usage_widget_size(expanded)
+    height = min(height, max(120, mh - 24))
+    if not isinstance(position, dict) or position.get("x") is None:
+        y = my + DEFAULT_TOP
+        anchor = "right"
+    else:
+        anchor = str(position.get("anchor") or "right")
+        if anchor not in ("left", "right"):
+            anchor = "right"
+        y = int(position["y"]) if position.get("y") is not None else my + DEFAULT_TOP
+    x = usage_widget_dock_x(anchor, width, (mx, my, mw, mh))
+    y = max(my, min(y, my + mh - min(height, mh)))
+    return {
+        "x": x,
+        "y": y,
+        "width": width,
+        "height": height,
+        "anchor": anchor,
+    }
+
+
+def configure_backend():
+    if os.environ.get("GDK_BACKEND"):
+        return
+    if os.environ.get("XDG_SESSION_TYPE") == "wayland" and os.environ.get("DISPLAY"):
+        os.environ["GDK_BACKEND"] = "x11"
+
+
+if __name__ == "__main__":
+    configure_backend()
+
+try:
+    import gi
+    gi.require_version("Gtk", "3.0")
+    gi.require_version("Gdk", "3.0")
+    from gi.repository import Gdk, Gio, GLib, Gtk
+    GTK_AVAILABLE = True
+except (ImportError, ValueError):
+    pass
+
+
+if GTK_AVAILABLE:
+    CSS = b"""
+    window.usage-widget { background: #0b1016; }
+    .usage-tab { background: #111820; color: #ffb457; padding: 8px 0; }
+    .usage-title { color: #ffb457; font-weight: 700; letter-spacing: 1px; }
+    .usage-live { color: #66d990; }
+    .usage-dim { color: #8b98a8; }
+    .usage-fg { color: #f6f8fb; }
+    .usage-chip { padding: 2px 8px; border-radius: 999px; background: rgba(255,255,255,0.04); color: #a8b3c1; }
+    .usage-chip:checked { background: rgba(0,188,235,0.16); color: #f6f8fb; }
+    progress, trough { min-height: 7px; border-radius: 99px; }
+    """
+
+    class UsageWidgetWindow(Gtk.ApplicationWindow):
+        def __init__(self, application):
+            super().__init__(application=application, title="Token Meter")
+            self.selected_id = ""
+            self.expanded = False
+            self.payload = {}
+            self.error = ""
+            self.position = load_widget_position()
+            self._press = None
+            self._dragging = False
+            self._pinning = False
+            self.set_decorated(False)
+            self.set_keep_above(True)
+            self.set_skip_taskbar_hint(True)
+            self.set_skip_pager_hint(True)
+            self.set_accept_focus(True)
+            self.set_resizable(False)
+            self.set_default_size(*COLLAPSED_SIZE)
+            self.set_position(Gtk.WindowPosition.NONE)
+            try:
+                self.set_type_hint(Gdk.WindowTypeHint.NORMAL)
+            except Exception:
+                pass
+            self.get_style_context().add_class("usage-widget")
+            provider = Gtk.CssProvider()
+            provider.load_from_data(CSS)
+            screen = Gdk.Screen.get_default()
+            if screen is not None:
+                Gtk.StyleContext.add_provider_for_screen(
+                    screen, provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION,
+                )
+            self.connect("delete-event", self._on_delete)
+            self.connect("realize", self._on_realize)
+            self.connect("map-event", self._on_map)
+            self.connect("size-allocate", self._on_size_allocate)
+            self.body = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=0)
+            self.add(self.body)
+            self.tab = Gtk.EventBox()
+            self.tab.get_style_context().add_class("usage-tab")
+            self.tab.set_size_request(*COLLAPSED_SIZE)
+            self.tab.set_visible_window(True)
+            self._bind_drag(self.tab, toggle=True)
+            self.tab_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
+            self.tab_box.set_valign(Gtk.Align.CENTER)
+            self.tab_percent = Gtk.Label(label="--")
+            self.tab_percent.get_style_context().add_class("usage-title")
+            self.tab_caption = Gtk.Label(label="LIMITS")
+            self.tab_caption.set_angle(90)
+            self.tab_caption.get_style_context().add_class("usage-dim")
+            self.tab_box.pack_start(self.tab_percent, False, False, 0)
+            self.tab_box.pack_start(self.tab_caption, False, False, 0)
+            self.tab.add(self.tab_box)
+            self.panel = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
+            self.panel.set_margin_top(10)
+            self.panel.set_margin_bottom(12)
+            self.panel.set_margin_start(12)
+            self.panel.set_margin_end(12)
+            self.panel.set_size_request(*EXPANDED_SIZE)
+            self.panel.set_no_show_all(True)
+            self.panel.hide()
+            self.chip_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=5)
+            self.chip_box.set_homogeneous(False)
+            self.head = Gtk.EventBox()
+            self.head.set_visible_window(False)
+            self._bind_drag(self.head, toggle=False)
+            head_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+            self.title_label = Gtk.Label(label="TOKEN METER")
+            self.title_label.set_xalign(0)
+            self.title_label.get_style_context().add_class("usage-title")
+            self.live_label = Gtk.Label(label="")
+            self.live_label.set_xalign(1)
+            self.live_label.get_style_context().add_class("usage-live")
+            head_row.pack_start(self.title_label, True, True, 0)
+            head_row.pack_end(self.live_label, False, False, 0)
+            self.head.add(head_row)
+            self.bars = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
+            self.sessions = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=4)
+            self.panel.pack_start(self.chip_box, False, False, 0)
+            self.panel.pack_start(self.head, False, False, 0)
+            self.panel.pack_start(self.bars, False, False, 0)
+            recent = Gtk.Label(label="RECENT")
+            recent.set_xalign(0)
+            recent.get_style_context().add_class("usage-dim")
+            self.panel.pack_start(recent, False, False, 0)
+            self.panel.pack_start(self.sessions, False, False, 0)
+            self.body.pack_start(self.tab, False, False, 0)
+            self.body.pack_start(self.panel, True, True, 0)
+            self.refresh()
+            GLib.timeout_add_seconds(POLL_SECONDS, self.refresh)
+            self._apply_frame()
+
+        def _bind_drag(self, widget, toggle):
+            widget.add_events(
+                Gdk.EventMask.BUTTON_PRESS_MASK
+                | Gdk.EventMask.BUTTON_RELEASE_MASK
+                | Gdk.EventMask.BUTTON_MOTION_MASK
+                | Gdk.EventMask.POINTER_MOTION_HINT_MASK
+            )
+            widget.connect("button-press-event", self._on_drag_press)
+            widget.connect("motion-notify-event", self._on_drag_motion)
+            widget.connect(
+                "button-release-event",
+                lambda w, event: self._on_drag_release(w, event, toggle),
+            )
+            try:
+                widget.connect("enter-notify-event", self._on_drag_cursor)
+            except TypeError:
+                pass
+
+        def _on_drag_cursor(self, widget, _event):
+            window = widget.get_window() or self.get_window()
+            display = Gdk.Display.get_default()
+            if window is None or display is None:
+                return False
+            try:
+                window.set_cursor(Gdk.Cursor.new_from_name(display, "grab"))
+            except Exception:
+                pass
+            return False
+
+        def _backend_x11(self):
+            display = Gdk.Display.get_default()
+            name = display.get_name() if display is not None else ""
+            backend = os.environ.get("GDK_BACKEND") or ""
+            return name.startswith(":") or backend == "x11"
+
+        def _monitor_geometry(self, monitor):
+            geo = monitor.get_geometry()
+            return (geo.x, geo.y, geo.width, geo.height)
+
+        def _monitor_at(self, x, y):
+            display = Gdk.Display.get_default()
+            monitor = display.get_primary_monitor() or display.get_monitor(0)
+            try:
+                at_point = display.get_monitor_at_point(int(x), int(y))
+                if at_point is not None:
+                    monitor = at_point
+            except Exception:
+                pass
+            return self._monitor_geometry(monitor)
+
+        def _monitor(self):
+            display = Gdk.Display.get_default()
+            x = y = 0
+            try:
+                x, y = self._window_origin()
+            except Exception:
+                pass
+            saved = self.position if isinstance(self.position, dict) else {}
+            if not x and not y and saved.get("x") is not None:
+                x = int(saved.get("x") or 0)
+                y = int(saved.get("y") or 0)
+            if not x and not y:
+                try:
+                    seat = display.get_default_seat()
+                    _screen, x, y = seat.get_pointer().get_position()
+                except Exception:
+                    pass
+            return self._monitor_at(x, y)
+
+        def _on_delete(self, *_args):
+            self.hide()
+            return True
+
+        def _on_realize(self, *_args):
+            gdk_win = self.get_window()
+            if gdk_win is None:
+                return
+            try:
+                if self._backend_x11():
+                    gdk_win.set_override_redirect(True)
+                gdk_win.set_keep_above(True)
+            except Exception:
+                pass
+
+        def _on_map(self, *_args):
+            GLib.idle_add(self._apply_frame)
+            GLib.timeout_add(80, self._apply_frame)
+            GLib.timeout_add(400, self._apply_frame)
+            return False
+
+        def _on_size_allocate(self, _widget, allocation):
+            if self._dragging or self._pinning:
+                return
+            if int(getattr(allocation, "width", 0) or 0) <= 1:
+                return
+            GLib.idle_add(self._pin_drawn_size)
+
+        def _on_drag_press(self, _widget, event):
+            if getattr(event, "button", 0) != 1:
+                return False
+            try:
+                win_x, win_y = self._window_origin()
+            except Exception:
+                win_x, win_y = 0, 0
+            self._press = (event.x_root, event.y_root, win_x, win_y, event.time)
+            self._dragging = False
+            return True
+
+        def _on_drag_motion(self, _widget, event):
+            if self._press is None:
+                return False
+            if not (event.state & Gdk.ModifierType.BUTTON1_MASK):
+                return False
+            dx = event.x_root - self._press[0]
+            dy = event.y_root - self._press[1]
+            if not self._dragging and abs(dx) + abs(dy) < DRAG_THRESHOLD:
+                return False
+            self._dragging = True
+            if self._backend_x11():
+                self._move_to(int(self._press[2] + dx), int(self._press[3] + dy))
+            else:
+                try:
+                    self.begin_move_drag(
+                        1, int(event.x_root), int(event.y_root), event.time,
+                    )
+                except Exception:
+                    self._move_to(int(self._press[2] + dx), int(self._press[3] + dy))
+                self._press = None
+            return True
+
+        def _on_drag_release(self, _widget, event, toggle):
+            if getattr(event, "button", 0) != 1:
+                return False
+            dragged = self._dragging
+            self._press = None
+            self._dragging = False
+            if dragged:
+                try:
+                    x, y = self._window_origin()
+                    width, height = self._drawn_size()
+                except Exception:
+                    return True
+                snapped = usage_widget_snap(x, y, width, height, self._monitor_at(x, y))
+                self.position = snapped
+                save_widget_position(self.position)
+                self._apply_frame()
+                return True
+            if toggle:
+                self.expanded = not self.expanded
+                self._apply_frame()
+            return True
+
+        def _drawn_size(self):
+            gdk_win = self.get_window()
+            if gdk_win is not None:
+                try:
+                    width, height = gdk_win.get_width(), gdk_win.get_height()
+                    if width > 1 and height > 1:
+                        return int(width), int(height)
+                except Exception:
+                    pass
+            return (
+                int(self.get_allocated_width() or COLLAPSED_SIZE[0]),
+                int(self.get_allocated_height() or COLLAPSED_SIZE[1]),
+            )
+
+        def _window_origin(self):
+            gdk_win = self.get_window()
+            if gdk_win is not None:
+                try:
+                    origin = gdk_win.get_origin()
+                    if isinstance(origin, tuple) and len(origin) >= 2:
+                        return int(origin[-2]), int(origin[-1])
+                except Exception:
+                    pass
+            try:
+                x, y = self.get_position()
+                return int(x), int(y)
+            except Exception:
+                return (
+                    int((self.position or {}).get("x") or 0),
+                    int((self.position or {}).get("y") or 0),
+                )
+
+        def _move_to(self, x, y, width=None, height=None):
+            drawn_w, drawn_h = self._drawn_size()
+            width = int(width if width is not None else drawn_w)
+            height = int(height if height is not None else drawn_h)
+            self.move(x, y)
+            gdk_win = self.get_window()
+            if gdk_win is not None:
+                try:
+                    gdk_win.move(x, y)
+                    gdk_win.move_resize(x, y, width, height)
+                except Exception:
+                    pass
+
+        def _pin_drawn_size(self):
+            if self._dragging or self._pinning:
+                return False
+            width, height = self._drawn_size()
+            if width <= 1:
+                return False
+            x, y = self._window_origin()
+            monitor = self._monitor_at(x, y)
+            anchor = str((self.position or {}).get("anchor") or "right")
+            if anchor not in ("left", "right"):
+                anchor = "right"
+            pinned_x = usage_widget_dock_x(anchor, width, monitor)
+            if abs(int(x) - pinned_x) <= 1:
+                return False
+            self._pinning = True
+            try:
+                self._move_to(pinned_x, y, width, height)
+                self.position = {
+                    "x": pinned_x,
+                    "y": int(y),
+                    "width": width,
+                    "height": height,
+                    "anchor": anchor,
+                }
+                save_widget_position(self.position)
+            finally:
+                self._pinning = False
+            return False
+
+        def _dock_order(self, anchor):
+            if anchor == "left":
+                wanted = (self.panel, self.tab)
+            else:
+                wanted = (self.tab, self.panel)
+            current = tuple(self.body.get_children())
+            if current == wanted:
+                return
+            for child in current:
+                self.body.remove(child)
+            for child in wanted:
+                expand = child is self.panel
+                self.body.pack_start(child, expand, expand, 0)
+
+        def _apply_frame(self):
+            if self._dragging:
+                return False
+            monitor = self._monitor()
+            frame = usage_widget_frame(self.expanded, self.position, monitor)
+            self._dock_order(frame["anchor"])
+            if self.expanded:
+                self.panel.show()
+            else:
+                self.panel.hide()
+            self.set_size_request(frame["width"], frame["height"])
+            drawn_w, drawn_h = self._drawn_size()
+            if self.expanded:
+                width = max(frame["width"], drawn_w)
+                height = max(frame["height"], drawn_h)
+            else:
+                width, height = frame["width"], frame["height"]
+            self.resize(width, height)
+            x = usage_widget_dock_x(frame["anchor"], width, monitor)
+            y = frame["y"]
+            self.position = {
+                "x": x,
+                "y": y,
+                "width": width,
+                "anchor": frame["anchor"],
+            }
+            self._move_to(x, y, width, height)
+            save_widget_position(self.position)
+            GLib.idle_add(self._pin_drawn_size)
+            return False
+
+        def _on_chip(self, button):
+            if not button.get_active():
+                return
+            provider_id = getattr(button, "token_meter_provider", "")
+            if provider_id == self.selected_id:
+                return
+            self.selected_id = provider_id
+            self._render_body()
+
+        def _clear(self, box):
+            for child in list(box.get_children()):
+                box.remove(child)
+
+        def _rebuild_chips(self, chips, selected_id):
+            current = [
+                getattr(child, "token_meter_provider", None)
+                for child in self.chip_box.get_children()
+            ]
+            expected = [""] + [chip["id"] for chip in chips]
+            if current != expected:
+                self._clear(self.chip_box)
+                group = None
+                for provider_id, label in [("", "All")] + [
+                    (chip["id"], chip["label"]) for chip in chips
+                ]:
+                    button = Gtk.RadioButton.new_with_label_from_widget(group, label)
+                    group = button
+                    button.set_mode(False)
+                    button.token_meter_provider = provider_id
+                    button.get_style_context().add_class("usage-chip")
+                    button.connect("toggled", self._on_chip)
+                    self.chip_box.pack_start(button, False, False, 0)
+                self.chip_box.show_all()
+            for button in self.chip_box.get_children():
+                want = getattr(button, "token_meter_provider", "") == selected_id
+                if button.get_active() != want:
+                    button.handler_block_by_func(self._on_chip)
+                    button.set_active(want)
+                    button.handler_unblock_by_func(self._on_chip)
+
+        def _bar_row(self, window):
+            used = window.get("used_percent")
+            try:
+                used = max(0.0, min(100.0, float(used or 0)))
+            except (TypeError, ValueError):
+                used = 0.0
+            row = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=2)
+            meta = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+            name = Gtk.Label(label=str(window.get("label") or "Limit"))
+            name.set_xalign(0)
+            name.get_style_context().add_class("usage-fg")
+            pct = Gtk.Label(label=percent_label(used))
+            pct.set_xalign(1)
+            pct.get_style_context().add_class("usage-fg")
+            meta.pack_start(name, True, True, 0)
+            meta.pack_end(pct, False, False, 0)
+            bar = Gtk.ProgressBar()
+            bar.set_fraction(used / 100.0)
+            row.pack_start(meta, False, False, 0)
+            row.pack_start(bar, False, False, 0)
+            return row
+
+        def _session_row(self, session):
+            button = Gtk.Button()
+            button.set_relief(Gtk.ReliefStyle.NONE)
+            inner = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+            name = Gtk.Label(label=str(session.get("name") or "Session"))
+            name.set_xalign(0)
+            name.get_style_context().add_class("usage-fg")
+            mark = Gtk.Label(label=str(session.get("label") or session.get("provider") or ""))
+            mark.set_xalign(1)
+            mark.get_style_context().add_class("usage-dim")
+            inner.pack_start(name, True, True, 0)
+            inner.pack_end(mark, False, False, 0)
+            button.add(inner)
+            session_id = str(session.get("id") or "")
+            button.connect("clicked", lambda *_args, sid=session_id: self._open_session(sid))
+            return button
+
+        def _open_session(self, session_id):
+            if not session_id:
+                return
+            try:
+                subprocess.Popen(
+                    ["xdg-open", session_url(session_id)],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    start_new_session=True,
+                )
+            except OSError:
+                pass
+
+        def _render_body(self):
+            view = usage_widget_view(self.payload, self.selected_id)
+            self.selected_id = view["selected_id"]
+            self._rebuild_chips(view["chips"], self.selected_id)
+            self.title_label.set_text(str(view["title"] or "Token Meter").upper())
+            if view["live_tps"] is not None and not view["ended"]:
+                self.live_label.set_text(
+                    "LIVE " + compact_number(view["live_tps"] * 60) + " tok/min"
+                )
+            else:
+                self.live_label.set_text("")
+            self.tab_percent.set_text(percent_label(view["hottest"]))
+            self._clear(self.bars)
+            if self.error:
+                err = Gtk.Label(label=self.error)
+                err.set_xalign(0)
+                err.set_line_wrap(True)
+                err.get_style_context().add_class("usage-dim")
+                self.bars.pack_start(err, False, False, 0)
+            elif view["quota_available"]:
+                for window in view["windows"]:
+                    self.bars.pack_start(self._bar_row(window), False, False, 0)
+            else:
+                empty = Gtk.Label(label="No provider limits reported.")
+                empty.set_xalign(0)
+                empty.get_style_context().add_class("usage-dim")
+                self.bars.pack_start(empty, False, False, 0)
+            self.bars.show_all()
+            self._clear(self.sessions)
+            if view["sessions"]:
+                for session in view["sessions"]:
+                    self.sessions.pack_start(self._session_row(session), False, False, 0)
+            else:
+                empty = Gtk.Label(label="No recent sessions.")
+                empty.set_xalign(0)
+                empty.get_style_context().add_class("usage-dim")
+                self.sessions.pack_start(empty, False, False, 0)
+            self.sessions.show_all()
+            if not self._dragging:
+                GLib.idle_add(self._apply_frame)
+
+        def refresh(self):
+            try:
+                self.payload = fetch_menubar()
+                self.error = ""
+            except (OSError, ValueError, URLError) as exc:
+                self.payload = {}
+                self.error = str(exc) or "Waiting for Token Meter"
+            self._render_body()
+            return True
+
+    class UsageWidgetApplication(Gtk.Application):
+        def __init__(self):
+            super().__init__(
+                application_id=APPLICATION_ID,
+                flags=Gio.ApplicationFlags.FLAGS_NONE,
+            )
+            self.window = None
+
+        def do_activate(self):
+            if self.window is None:
+                self.window = UsageWidgetWindow(self)
+                self.add_window(self.window)
+            self.window.show_all()
+            self.window._apply_frame()
+            self.window.present()
+            GLib.idle_add(self.window._apply_frame)
+
+
+def gtk_requirements_message():
+    return (
+        "Token Meter's usage widget needs GTK 3 and PyGObject.\n"
+        "Debian/Ubuntu: sudo apt install python3-gi\n"
+        "Fedora: sudo dnf install python3-gobject\n"
+        "Arch: sudo pacman -S python-gobject"
+    )
+
+
+def run_smoke():
+    fixture = os.environ.get("TOKEN_METER_WIDGET_FIXTURE")
+    if fixture:
+        payload = json.loads(fixture)
+    else:
+        payload = fetch_menubar()
+    selected = os.environ.get("TOKEN_METER_WIDGET_PROVIDER") or ""
+    print(json.dumps(usage_widget_view(payload, selected), sort_keys=True))
+
+
+def main(argv=None):
+    argv = list(sys.argv if argv is None else argv)
+    if "--check" in argv:
+        return 0
+    if "--smoke" in argv or os.environ.get("TOKEN_METER_WIDGET_SMOKE") == "1":
+        try:
+            run_smoke()
+        except (OSError, ValueError, URLError, json.JSONDecodeError) as exc:
+            print(f"Token Meter widget smoke failed: {exc}", file=sys.stderr)
+            return 1
+        return 0
+    if not GTK_AVAILABLE:
+        print(gtk_requirements_message(), file=sys.stderr)
+        return 1
+    configure_backend()
+    GLib.set_prgname("token-meter-widget")
+    try:
+        Gdk.set_program_class("token-meter-widget")
+    except Exception:
+        pass
+    app = UsageWidgetApplication()
+    return app.run(argv)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/page.html
+++ b/page.html
@@ -502,7 +502,57 @@ body.sessionRoute #view-session.sessionDetail .previewKpi.previewSpeed .v{color:
 .frustrationSection .signalRankTrack i,.frustrationSection .chatSignalTrack i{background:linear-gradient(90deg,var(--signal-primary),var(--signal-secondary))}
 .frustrationSection .termPanel .signalRankTrack i{background:linear-gradient(90deg,var(--signal-secondary),var(--signal-primary))}
 .frustrationSection .signalRateBadge{border-color:var(--signal-edge);background:var(--signal-wash);color:var(--signal-secondary)}
+.usageWidget{position:fixed;top:92px;right:0;z-index:80;display:flex;align-items:stretch;pointer-events:none}
+.usageWidgetTab{pointer-events:auto;width:34px;min-height:148px;border:1px solid var(--line2);border-right:0;border-radius:10px 0 0 10px;background:linear-gradient(180deg,rgba(17,24,32,.96),rgba(11,16,22,.96));color:var(--orange3);box-shadow:var(--shadow-soft);cursor:pointer;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:8px;padding:10px 0}
+.usageWidgetTab b{font:800 11px/1 ui-monospace,"SF Mono",Menlo,monospace}
+.usageWidgetTab small{writing-mode:vertical-rl;transform:rotate(180deg);color:var(--faint);font-size:10px;font-weight:760;letter-spacing:.06em;text-transform:uppercase}
+.usageWidgetPanel{pointer-events:auto;width:300px;max-height:calc(100vh - 120px);overflow:auto;border:1px solid var(--line2);border-right:0;border-radius:12px 0 0 12px;background:linear-gradient(180deg,rgba(14,20,28,.98),rgba(8,12,18,.98));box-shadow:var(--shadow);padding:12px 13px 14px}
+.usageWidgetChips{display:flex;flex-wrap:wrap;gap:5px;margin:0 0 10px}
+.usageWidgetChips button{border:1px solid var(--line2);background:rgba(255,255,255,.03);color:var(--dim);border-radius:999px;padding:3px 8px;font:780 10px/1.2 ui-sans-serif,system-ui,sans-serif;letter-spacing:.04em;text-transform:uppercase;cursor:pointer}
+.usageWidgetChips button[aria-selected=true]{border-color:var(--accent);color:var(--fg);background:rgba(0,188,235,.12)}
+.usageWidgetHead{display:flex;align-items:center;justify-content:space-between;gap:8px;margin-bottom:10px}
+.usageWidgetHead strong{font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:var(--orange3)}
+.usageWidgetLive{color:var(--good);font:780 11px/1 ui-monospace,"SF Mono",Menlo,monospace}
+.usageWidgetGauges{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:8px;margin:0 0 12px}
+.usageGauge{display:grid;justify-items:center;gap:4px}
+.usageGauge svg{width:72px;height:72px}
+.usageGauge b{font:820 15px/1 ui-monospace,"SF Mono",Menlo,monospace}
+.usageGauge span{color:var(--faint);font-size:9.5px;text-transform:uppercase;letter-spacing:.04em}
+.usageBars{display:grid;gap:8px;margin:0 0 12px}
+.usageBar{display:grid;gap:3px}
+.usageBarMeta{display:flex;justify-content:space-between;gap:8px;font-size:11px}
+.usageBarMeta b{font-weight:760}
+.usageBarTrack{height:7px;border-radius:99px;background:rgba(255,255,255,.08);overflow:hidden}
+.usageBarTrack i{display:block;height:100%;border-radius:99px;background:linear-gradient(90deg,var(--accent),var(--orange3))}
+.usageBar.hot .usageBarTrack i{background:linear-gradient(90deg,var(--warn),var(--bad))}
+.usageBar.dead .usageBarTrack i{background:var(--bad)}
+.usageSessions{display:grid;gap:4px}
+.usageSessions a,.usageEmpty{display:flex;justify-content:space-between;gap:8px;padding:7px 8px;border-radius:8px;border:1px solid var(--line);color:var(--fg);text-decoration:none;font-size:12px}
+.usageSessions a:hover{border-color:var(--line2);background:rgba(255,255,255,.03)}
+.usageSessions small{color:var(--faint)}
+.usageEmpty{color:var(--dim)}
+body.usageWidgetStandalone{background:#07090c}
+body.usageWidgetStandalone .wrap,body.usageWidgetStandalone .fieldTipPopup{display:none!important}
+body.usageWidgetStandalone .usageWidget{top:0;height:100vh}
+body.usageWidgetStandalone .usageWidgetPanel{max-height:100vh;border-radius:0;height:100vh}
+@media(max-width:1024px){.usageWidget{top:78px}.usageWidgetPanel{width:260px}}
 </style></head><body class=spectrumApp>
+<aside id=usage-widget class=usageWidget>
+ <button type=button class=usageWidgetTab id=usage-widget-tab aria-expanded=false aria-controls=usage-widget-panel title="Usage widget">
+  <b id=usage-widget-tab-pct>--</b>
+  <small>Limits</small>
+ </button>
+ <div class=usageWidgetPanel id=usage-widget-panel hidden>
+  <div class=usageWidgetChips id=usage-widget-chips role=tablist aria-label="Runtime"></div>
+  <div class=usageWidgetHead>
+   <strong id=usage-widget-runtime>Token Meter</strong>
+   <span class=usageWidgetLive id=usage-widget-live></span>
+  </div>
+  <div class=usageWidgetGauges id=usage-widget-gauges></div>
+  <div class=usageBars id=usage-widget-bars></div>
+  <div class=usageSessions id=usage-widget-sessions></div>
+ </div>
+</aside>
 <!--
 THESIS: Sessions are live instruments, not a generic grid of dark cards.
 OWN-WORLD: Token Meter ink, cyan and sky light, restrained violet and orange accents, Tektur display type, and layered operational gradients.
@@ -1862,6 +1912,12 @@ showCurrentPanel(currentPanel);
 function applyHashRoute(){
  const h=(location.hash||'').replace(/^#/,'');
  const panel=PANEL_ALIAS[h]||h;
+ if(h==='widget'||location.pathname==='/widget'){
+  document.body.classList.add('usageWidgetStandalone');
+  if(typeof syncUsageWidgetFrame==='function')syncUsageWidgetFrame();
+  return;
+ }
+ document.body.classList.remove('usageWidgetStandalone');
  const legacyGlobal=h==='global'||h==='global-logs'||/^global-(overview|evidence)$/.test(h);
  if(h==='sessions'||h==='sessions-all'||h==='current-sessions'){
  const scope=h==='sessions-all'?'all':'current',route=sessionScopeRoute(scope);
@@ -1988,6 +2044,128 @@ function applyLocationRoute(){
 applyLocationRoute();
 window.addEventListener('hashchange',applyHashRoute);
 window.addEventListener('popstate',applyLocationRoute);
+
+const USAGE_WIDGET_KEY='tm_usage_widget_open';
+const USAGE_WIDGET_PROVIDER_KEY='tm_usage_widget_provider';
+let usageWidgetOpen=localStorage.getItem(USAGE_WIDGET_KEY)==='1';
+let usageWidgetProvider=localStorage.getItem(USAGE_WIDGET_PROVIDER_KEY)||'';
+let usageWidgetTimer=0,usageWidgetPayload=null;
+function usageWidgetStandalone(){return (location.hash||'').replace(/^#/,'')==='widget'||location.pathname==='/widget';}
+function usageResetLabel(resetAt){
+ const remaining=Number(resetAt||0)-Date.now()/1000;
+ if(!resetAt)return '';
+ if(remaining<=0)return 'resetting';
+ return idleLabel(remaining).replace(' idle','')+' left';
+}
+function usageArc(percent,hot){
+ const p=Math.max(0,Math.min(100,Number(percent)||0)),c=2*Math.PI*26,dash=c*p/100;
+ const color=hot?'var(--bad)':(p>=80?'var(--warn)':'var(--accent)');
+ return `<svg viewBox="0 0 72 72" aria-hidden=true><circle cx="36" cy="36" r="26" fill="none" stroke="rgba(255,255,255,.08)" stroke-width="6"/><circle cx="36" cy="36" r="26" fill="none" stroke="${color}" stroke-width="6" stroke-linecap="round" stroke-dasharray="${dash} ${c}" transform="rotate(-90 36 36)"/></svg>`;
+}
+function usageWidgetChips(payload){
+ const catalog=payload.runtime_catalog||{};
+ const chips=[],seen=new Set();
+ const add=(id,label)=>{
+  id=String(id||'');
+  if(!id||id==='unknown-runtime'||seen.has(id))return;
+  seen.add(id);
+  const meta=catalog[id]||{};
+  chips.push({id,label:meta.label||label||id});
+ };
+ (payload.provider_quotas||[]).forEach(row=>row&&add(row.id,row.label));
+ (payload.recent_sessions||[]).forEach(row=>row&&add(row.provider,row.label));
+ return chips;
+}
+function usageWidgetView(payload,selectedId){
+ const chips=usageWidgetChips(payload||{});
+ if(selectedId&&!chips.some(row=>row.id===selectedId))selectedId='';
+ let quotas=(payload.provider_quotas||[]).filter(row=>row&&(row.windows||[]).length);
+ let sessions=(payload.recent_sessions||[]).filter(row=>row);
+ if(selectedId){
+  quotas=quotas.filter(row=>row.id===selectedId);
+  sessions=sessions.filter(row=>row.provider===selectedId);
+ }
+ const ranked=quotas.slice().sort((a,b)=>{
+  const hot=row=>(row.windows||[]).reduce((best,item)=>Math.max(best,Number(item.used_percent||0)),-1);
+  return hot(b)-hot(a);
+ });
+ const primary=selectedId?quotas[0]:ranked[0];
+ const windows=(primary&&primary.windows)||[];
+ const hottest=windows.reduce((best,row)=>{
+  const used=Number(row.used_percent);
+  return Number.isFinite(used)&&(best==null||used>best)?used:best;
+ },null);
+ const live=payload.live_throughput||{};
+ const liveOk=live.available&&(!selectedId||payload.provider===selectedId);
+ return {
+  chips,selectedId,windows,sessions:sessions.slice(0,5),hottest,
+  title:(primary&&primary.label)||(chips.find(row=>row.id===selectedId)||{}).label||(payload.source&&payload.source.label)||'Token Meter',
+  liveTps:liveOk?Number(live.output_tps||0):0,
+ };
+}
+function renderUsageWidget(payload){
+ usageWidgetPayload=payload||{};
+ const view=usageWidgetView(payload,usageWidgetProvider);
+ usageWidgetProvider=view.selectedId;
+ const windows=view.windows,top=windows.slice(0,3);
+ $('usage-widget-tab-pct').textContent=view.hottest==null?'--':Math.round(view.hottest)+'%';
+ $('usage-widget-runtime').textContent=view.title;
+ if(view.liveTps&&!payload.ended){
+  $('usage-widget-live').textContent='LIVE '+compactNumber(view.liveTps*60)+' tok/min';
+ }else $('usage-widget-live').textContent='';
+ $('usage-widget-chips').innerHTML=[{id:'',label:'All'},...view.chips].map(row=>{
+  const on=row.id===view.selectedId;
+  return `<button type=button role=tab aria-selected="${on?'true':'false'}" data-usage-provider="${esc(row.id)}">${esc(row.label)}</button>`;
+ }).join('');
+ $('usage-widget-gauges').innerHTML=top.map(row=>{
+  const used=Number(row.used_percent||0),hot=used>=95||(row.pace&&row.pace.summary==='exhausted');
+  return `<div class=usageGauge>${usageArc(used,hot)}<b>${Math.round(used)}%</b><span>${esc(row.label||'Limit')}</span></div>`;
+ }).join('');
+ $('usage-widget-bars').innerHTML=windows.map(row=>{
+  const used=Number(row.used_percent||0),hot=used>=80,dead=used>=100||(row.pace&&row.pace.summary==='exhausted');
+  const reset=usageResetLabel(row.reset_at);
+  return `<div class="usageBar${dead?' dead':hot?' hot':''}"><div class=usageBarMeta><span>${esc(row.label||'Limit')}</span><b>${Math.round(used)}%</b></div><div class=usageBarTrack><i style="width:${Math.max(0,Math.min(100,used))}%"></i></div><div class=usageBarMeta><small>${esc(dead?'exhausted':(row.pace&&row.pace.summary)||reset)}</small><small>${esc(reset)}</small></div></div>`;
+ }).join('')||'<div class=usageEmpty>No provider limits reported.</div>';
+ $('usage-widget-sessions').innerHTML=view.sessions.length?view.sessions.map(row=>{
+  const href=`/sessions/${encodeURIComponent(row.id||'')}#summary`;
+  const label=esc(row.label||row.provider||'session');
+  return `<a href="${href}"><span>${esc(row.name||'Session')}</span><small>${label}</small></a>`;
+ }).join(''):'<div class=usageEmpty>No recent sessions.</div>';
+}
+function syncUsageWidgetFrame(){
+ const standalone=usageWidgetStandalone(),open=usageWidgetOpen;
+ document.body.classList.toggle('usageWidgetStandalone',standalone);
+ $('usage-widget-panel').hidden=!open;
+ $('usage-widget-tab').setAttribute('aria-expanded',open?'true':'false');
+ $('usage-widget-tab').hidden=standalone&&open;
+ const width=open?300:36,height=open?520:168;
+ try{
+  if(window.webkit&&window.webkit.messageHandlers&&window.webkit.messageHandlers.tokenMeterWidget)
+   window.webkit.messageHandlers.tokenMeterWidget.postMessage({width,height,open});
+ }catch(e){}
+}
+function setUsageWidgetOpen(open){
+ usageWidgetOpen=Boolean(open);
+ localStorage.setItem(USAGE_WIDGET_KEY,usageWidgetOpen?'1':'0');
+ syncUsageWidgetFrame();
+}
+function setUsageWidgetProvider(id){
+ usageWidgetProvider=String(id||'');
+ localStorage.setItem(USAGE_WIDGET_PROVIDER_KEY,usageWidgetProvider);
+ if(usageWidgetPayload)renderUsageWidget(usageWidgetPayload);
+}
+function pollUsageWidget(){
+ fetch('/menubar',{cache:'no-store'}).then(r=>r.json()).then(renderUsageWidget).catch(()=>{});
+}
+$('usage-widget-tab').onclick=()=>setUsageWidgetOpen(!usageWidgetOpen);
+$('usage-widget-chips').onclick=event=>{
+ const button=event.target.closest('[data-usage-provider]');
+ if(button)setUsageWidgetProvider(button.dataset.usageProvider||'');
+};
+if(usageWidgetStandalone())usageWidgetOpen=true;
+syncUsageWidgetFrame();
+pollUsageWidget();
+usageWidgetTimer=setInterval(pollUsageWidget,4000);
 
 const canNotify=('Notification' in window);
 const notifySecure=window.isSecureContext||['localhost','127.0.0.1','::1'].includes(location.hostname);

--- a/page.html
+++ b/page.html
@@ -4336,9 +4336,9 @@ function dailyDeltaLabel(current,baseline){
  return value>0?`+${value}%`:value<0?`\u2212${Math.abs(value)}%`:'0%';
 }
 // spend-range-logic-start
-const SPEND_RUNTIME_COLORS={claude:'#f26722',codex:'#04a4b0',cursor:'#a974f7',opencode:'#fa5762',kiro:'#868ec2',unknown:'#889099'};
-const SPEND_RUNTIME_ORDER=['claude','codex','cursor','opencode','kiro','unknown'];
-const SPEND_RUNTIME_LABELS={claude:'Claude',codex:'Codex',cursor:'Cursor',opencode:'OpenCode',kiro:'Kiro',unknown:'Unknown'};
+const SPEND_RUNTIME_COLORS={claude:'#f26722',codex:'#04a4b0',cursor:'#a974f7',opencode:'#fa5762',kiro:'#868ec2',grok:'#00bceb',unknown:'#889099'};
+const SPEND_RUNTIME_ORDER=['claude','codex','cursor','opencode','kiro','grok','unknown'];
+const SPEND_RUNTIME_LABELS={claude:'Claude',codex:'Codex',cursor:'Cursor',opencode:'OpenCode',kiro:'Kiro',grok:'Grok',unknown:'Unknown'};
 function spendDayDate(day){
  const match=/^(\d{4})-(\d{2})-(\d{2})$/.exec(String(day||''));
  if(!match)return null;

--- a/runtime-manifest.txt
+++ b/runtime-manifest.txt
@@ -6,6 +6,7 @@ required token_meter_mcp.py
 required menubar/TokenMeterMenuBar.swift
 required menubar/Info.plist
 required menubar/token_meter_tray.py
+required menubar/token_meter_widget.py
 required assets/brand/logo-splunk-acc-rgb-w.png
 required scripts/install
 required scripts/install-linux

--- a/scripts/install-linux
+++ b/scripts/install-linux
@@ -127,7 +127,7 @@ while read -r entry_kind relative_path _; do
 done < "$RUNTIME_MANIFEST"
 chmod 755 "$INSTALL_ROOT"/scripts/*
 
-chmod 755 "$INSTALL_ROOT/menubar/token_meter_tray.py"
+chmod 755 "$INSTALL_ROOT/menubar/token_meter_tray.py" "$INSTALL_ROOT/menubar/token_meter_widget.py"
 PYTHONPATH="$SOURCE_ROOT" python3 -m token_meter.packaging parity \
   "$SOURCE_ROOT" "$INSTALL_ROOT" "$RUNTIME_MANIFEST" \
   || fail "the staged runtime does not match the source manifest."

--- a/scripts/run-tray.ps1
+++ b/scripts/run-tray.ps1
@@ -141,6 +141,77 @@ function Get-RuntimeLabel($State, [string]$Provider) {
     ))
 }
 
+function Get-UsageWidgetChips($State) {
+    $Chips = @()
+    $Seen = New-Object 'System.Collections.Generic.HashSet[string]'
+    foreach ($Row in @(Get-Value $State "provider_quotas" @())) {
+        $Id = [string](Get-Value $Row "id" "")
+        if (-not $Id -or $Id -eq "unknown-runtime" -or -not $Seen.Add($Id)) {
+            continue
+        }
+        $Chips += [pscustomobject]@{
+            id = $Id
+            label = Get-RuntimeLabel $State $Id
+        }
+    }
+    foreach ($Row in @(Get-Value $State "recent_sessions" @())) {
+        $Id = [string](Get-Value $Row "provider" "")
+        if (-not $Id -or $Id -eq "unknown-runtime" -or -not $Seen.Add($Id)) {
+            continue
+        }
+        $Chips += [pscustomobject]@{
+            id = $Id
+            label = Get-RuntimeLabel $State $Id
+        }
+    }
+    return @($Chips)
+}
+
+function Get-UsageWidgetView($State, [string]$ProviderId) {
+    $Chips = @(Get-UsageWidgetChips $State)
+    if ($ProviderId -and -not ($Chips | Where-Object { $_.id -eq $ProviderId })) {
+        $ProviderId = ""
+    }
+    $Quotas = @(Get-Value $State "provider_quotas" @())
+    $Sessions = @(Get-Value $State "recent_sessions" @())
+    if ($ProviderId) {
+        $Quotas = @($Quotas | Where-Object { [string](Get-Value $_ "id" "") -eq $ProviderId })
+        $Sessions = @($Sessions | Where-Object { [string](Get-Value $_ "provider" "") -eq $ProviderId })
+    }
+    $Windows = @()
+    $Title = "Token Meter"
+    if ($Quotas.Count -gt 0) {
+        $Primary = $Quotas[0]
+        if (-not $ProviderId) {
+            $Primary = $Quotas | Sort-Object {
+                (@(Get-Value $_ "windows" @()) | Measure-Object -Property used_percent -Maximum).Maximum
+            } -Descending | Select-Object -First 1
+        }
+        $Windows = @(Get-Value $Primary "windows" @())
+        $Title = [string](Get-Value $Primary "label" (Get-RuntimeLabel $State ([string](Get-Value $Primary "id" ""))))
+    } elseif ($ProviderId) {
+        $Title = Get-RuntimeLabel $State $ProviderId
+    }
+    $Hottest = $null
+    foreach ($Window in $Windows) {
+        $Used = [double](Get-Value $Window "used_percent" 0)
+        if ($null -eq $Hottest -or $Used -gt $Hottest) { $Hottest = $Used }
+    }
+    $Live = Get-Value $State "live_throughput" $null
+    $LiveOk = [bool](Get-Value $Live "available" $false) -and (
+        -not $ProviderId -or [string](Get-Value $State "provider" "") -eq $ProviderId
+    )
+    return [pscustomobject]@{
+        chips = $Chips
+        selectedId = $ProviderId
+        title = $Title
+        windows = $Windows
+        sessions = @($Sessions | Select-Object -First 5)
+        hottest = $Hottest
+        liveTps = if ($LiveOk) { [double](Get-Value $Live "output_tps" 0) } else { 0 }
+    }
+}
+
 function New-TokenMeterIcon {
     $Bitmap = New-Object System.Drawing.Bitmap(
         32,
@@ -276,6 +347,8 @@ $StatusPath = Join-Path $RuntimeRoot "tray.status.json"
 $script:BaseUrl = "http://127.0.0.1:8722"
 $script:SelectedSessionId = ""
 $script:LastState = $null
+$script:UsageProviderId = ""
+$script:UsageChipRects = @()
 $script:Connected = $false
 $script:OpenProbePath = $OpenProbePath
 
@@ -293,6 +366,154 @@ function Write-TrayStatus([bool]$Ready, [bool]$Connected) {
         [System.Text.UTF8Encoding]::new($false)
     )
     Move-Item -LiteralPath $Temporary -Destination $StatusPath -Force
+}
+
+function Place-UsageWidget($Form, [int]$Width, [int]$Height) {
+    $Work = [System.Windows.Forms.Screen]::PrimaryScreen.WorkingArea
+    $Form.Size = New-Object System.Drawing.Size $Width, $Height
+    $Form.Location = New-Object System.Drawing.Point (($Work.Right - $Width), ($Work.Top + 96))
+}
+
+function Toggle-UsageWidgetExpanded {
+    if (-not $script:UsageForm -or $script:UsageForm.IsDisposed) {
+        return
+    }
+    $script:UsageExpanded = -not $script:UsageExpanded
+    if ($script:UsageExpanded) {
+        Place-UsageWidget $script:UsageForm 300 520
+    } else {
+        Place-UsageWidget $script:UsageForm 36 168
+    }
+    $script:UsageForm.Invalidate()
+}
+
+function Handle-UsageWidgetClick($Event) {
+    if ($script:UsageExpanded) {
+        foreach ($Chip in @($script:UsageChipRects)) {
+            if ($Chip.Rect.Contains($Event.Location)) {
+                $script:UsageProviderId = [string]$Chip.id
+                $script:UsageForm.Invalidate()
+                return
+            }
+        }
+    }
+    Toggle-UsageWidgetExpanded
+}
+
+function Draw-UsageWidget($Graphics, $Form) {
+    $Graphics.Clear([System.Drawing.Color]::FromArgb(11, 16, 22))
+    $Accent = [System.Drawing.Color]::FromArgb(0, 188, 235)
+    $Text = [System.Drawing.Color]::FromArgb(246, 248, 251)
+    $Dim = [System.Drawing.Color]::FromArgb(168, 179, 193)
+    $Warn = [System.Drawing.Color]::FromArgb(255, 180, 87)
+    $Bad = [System.Drawing.Color]::FromArgb(255, 111, 111)
+    $TextBrush = New-Object System.Drawing.SolidBrush $Text
+    $DimBrush = New-Object System.Drawing.SolidBrush $Dim
+    $AccentBrush = New-Object System.Drawing.SolidBrush $Accent
+    $ChipBrush = New-Object System.Drawing.SolidBrush ([System.Drawing.Color]::FromArgb(18, 188, 235, 40))
+    $Small = New-Object System.Drawing.Font "Segoe UI", 8.5
+    $Bold = New-Object System.Drawing.Font "Segoe UI", 10, [System.Drawing.FontStyle]::Bold
+    $View = Get-UsageWidgetView $script:LastState ([string]$script:UsageProviderId)
+    $script:UsageChipRects = @()
+    if (-not $script:UsageExpanded) {
+        $Graphics.FillRectangle($AccentBrush, 0, 0, 4, $Form.Height)
+        $Format = New-Object System.Drawing.StringFormat
+        $Format.FormatFlags = [System.Drawing.StringFormatFlags]::DirectionVertical
+        $Graphics.DrawString("LIMITS", $Small, $DimBrush, 10, 24, $Format)
+        $Hottest = if ($null -eq $View.hottest) { 0 } else { [double]$View.hottest }
+        $Graphics.DrawString(("{0:0}%" -f $Hottest), $Bold, $AccentBrush, 4, 110)
+        $Small.Dispose(); $Bold.Dispose(); $TextBrush.Dispose(); $DimBrush.Dispose(); $AccentBrush.Dispose(); $ChipBrush.Dispose()
+        return
+    }
+    $X = 12
+    $Y = 10
+    foreach ($Chip in @([pscustomobject]@{ id = ""; label = "All" }) + @($View.chips)) {
+        $Label = [string]$Chip.label
+        $Width = [math]::Max(36, [int]$Graphics.MeasureString($Label, $Small).Width + 12)
+        $Rect = New-Object System.Drawing.Rectangle $X, $Y, $Width, 18
+        $script:UsageChipRects += [pscustomobject]@{ id = [string]$Chip.id; Rect = $Rect }
+        if ([string]$Chip.id -eq [string]$View.selectedId) {
+            $Graphics.FillRectangle($ChipBrush, $Rect)
+            $Graphics.DrawRectangle((New-Object System.Drawing.Pen $Accent), $Rect)
+            $Graphics.DrawString($Label, $Small, $TextBrush, $X + 5, $Y + 2)
+        } else {
+            $Graphics.DrawRectangle((New-Object System.Drawing.Pen ([System.Drawing.Color]::FromArgb(60, 70, 82))), $Rect)
+            $Graphics.DrawString($Label, $Small, $DimBrush, $X + 5, $Y + 2)
+        }
+        $X += $Width + 6
+        if ($X -gt 250) { $X = 12; $Y += 22 }
+    }
+    $Y += 26
+    $Graphics.DrawString(([string]$View.title).ToUpper(), $Small, $AccentBrush, 12, $Y)
+    if ([double]$View.liveTps -gt 0) {
+        $TokMin = [double]$View.liveTps * 60
+        $Graphics.DrawString(("LIVE {0:0} tok/min" -f $TokMin), $Small, (New-Object System.Drawing.SolidBrush ([System.Drawing.Color]::FromArgb(102, 217, 144))), 160, $Y)
+    }
+    $Y += 22
+    $Windows = @($View.windows)
+    if ($Windows.Count -eq 0) {
+        $Graphics.DrawString("No provider limits reported.", $Small, $DimBrush, 12, $Y)
+        $Y += 20
+    }
+    foreach ($Window in $Windows) {
+        $Label = [string](Get-Value $Window "label" "Limit")
+        $Used = [math]::Max(0, [math]::Min(100, [double](Get-Value $Window "used_percent" 0)))
+        $Fill = if ($Used -ge 95) { $Bad } elseif ($Used -ge 80) { $Warn } else { $Accent }
+        $Graphics.DrawString($Label, $Small, $TextBrush, 12, $Y)
+        $Graphics.DrawString(("{0:0}%" -f $Used), $Small, $TextBrush, 240, $Y)
+        $Y += 16
+        $Graphics.FillRectangle((New-Object System.Drawing.SolidBrush ([System.Drawing.Color]::FromArgb(36, 42, 50))), 12, $Y, 276, 7)
+        $Graphics.FillRectangle((New-Object System.Drawing.SolidBrush $Fill), 12, $Y, [int](276 * $Used / 100), 7)
+        $Y += 18
+    }
+    $Y += 8
+    $Graphics.DrawString("RECENT", $Small, $DimBrush, 12, $Y)
+    $Y += 18
+    foreach ($Row in @($View.sessions)) {
+        $Name = Limit-Text ([string](Get-Value $Row "name" "Session")) 28
+        $Label = Limit-Text ([string](Get-Value $Row "label" (Get-Value $Row "provider" ""))) 12
+        $Graphics.DrawString($Name, $Small, $TextBrush, 12, $Y)
+        $Graphics.DrawString($Label, $Small, $DimBrush, 210, $Y)
+        $Y += 18
+    }
+    $Small.Dispose(); $Bold.Dispose(); $TextBrush.Dispose(); $DimBrush.Dispose(); $AccentBrush.Dispose(); $ChipBrush.Dispose()
+}
+
+function Hide-UsageWidget {
+    if ($script:UsageForm -and -not $script:UsageForm.IsDisposed) {
+        $script:UsageForm.Hide()
+    }
+}
+
+function Show-UsageWidget {
+    if ($script:OpenProbePath) {
+        [System.IO.File]::WriteAllText(
+            $script:OpenProbePath,
+            "$($script:BaseUrl)/#widget",
+            [System.Text.UTF8Encoding]::new($false)
+        )
+        return
+    }
+    if ($script:UsageForm -and -not $script:UsageForm.IsDisposed) {
+        $script:UsageForm.Show()
+        $script:UsageForm.Invalidate()
+        return
+    }
+    $Form = New-Object System.Windows.Forms.Form
+    $Form.Text = "Token Meter"
+    $Form.FormBorderStyle = [System.Windows.Forms.FormBorderStyle]::None
+    $Form.TopMost = $true
+    $Form.ShowInTaskbar = $true
+    $Form.StartPosition = [System.Windows.Forms.FormStartPosition]::Manual
+    $Form.BackColor = [System.Drawing.Color]::FromArgb(11, 16, 22)
+    $script:UsageExpanded = $false
+    $script:UsageProviderId = [string]$script:UsageProviderId
+    $script:UsageChipRects = @()
+    Place-UsageWidget $Form 36 168
+    $Form.add_Paint({ param($Sender, $Event) Draw-UsageWidget $Event.Graphics $Sender })
+    $Form.add_MouseClick({ param($Sender, $Event) Handle-UsageWidgetClick $Event })
+    $script:UsageForm = $Form
+    $Form.Show()
 }
 
 function Open-TokenMeterUrl([string]$Url) {
@@ -451,6 +672,9 @@ function Update-RecentSessions($State) {
 function Update-TrayMenu($State) {
     $script:NotifyIcon.Text = Format-TrayText $State
     $script:StatusItem.Text = Format-MenuStatus $State
+    if ($script:UsageForm -and -not $script:UsageForm.IsDisposed) {
+        $script:UsageForm.Invalidate()
+    }
 
     $Recommendation = Get-Value $State "recommendation" $null
     $RecommendationLabel = [string](Get-Value $Recommendation "label" "Waiting for guidance")
@@ -525,6 +749,18 @@ $script:ActivityItem.Enabled = $false
 $Menu.Items.Add($script:ActivityItem) | Out-Null
 $Menu.Items.Add((New-Object System.Windows.Forms.ToolStripSeparator)) | Out-Null
 
+$OpenWidget = New-Object System.Windows.Forms.ToolStripMenuItem
+$OpenWidget.Text = "Usage widget"
+$OpenWidget.CheckOnClick = $true
+$OpenWidget.add_Click({
+    if ($OpenWidget.Checked) {
+        Show-UsageWidget
+    } else {
+        Hide-UsageWidget
+    }
+})
+$Menu.Items.Add($OpenWidget) | Out-Null
+
 $OpenDashboard = New-Object System.Windows.Forms.ToolStripMenuItem
 $OpenDashboard.Text = "Open dashboard"
 $OpenDashboard.add_Click({ Open-TokenMeterUrl (Current-DashboardUrl) })
@@ -572,6 +808,10 @@ try {
     [System.IO.File]::WriteAllText($PidPath, "$PID`r`n", [System.Text.UTF8Encoding]::new($false))
     Invoke-TrayRefresh
     $Timer.Start()
+    if (-not $SmokeTest) {
+        Show-UsageWidget
+        $OpenWidget.Checked = $true
+    }
     [System.Windows.Forms.Application]::Run($script:Context)
 } finally {
     $Timer.Stop()

--- a/scripts/run-tray.ps1
+++ b/scripts/run-tray.ps1
@@ -368,10 +368,30 @@ function Write-TrayStatus([bool]$Ready, [bool]$Connected) {
     Move-Item -LiteralPath $Temporary -Destination $StatusPath -Force
 }
 
+function Screen-ForUsageWidget($Form) {
+    $Anchor = if ($Form -and $Form.Location) { $Form.Location } else { [System.Windows.Forms.Cursor]::Position }
+    return [System.Windows.Forms.Screen]::FromPoint($Anchor)
+}
+
+function Snap-UsageWidget($Form) {
+    if (-not $Form -or $Form.IsDisposed) {
+        return
+    }
+    $Work = (Screen-ForUsageWidget $Form).WorkingArea
+    $Mid = $Form.Left + [int]($Form.Width / 2)
+    $X = if ($Mid -ge ($Work.Left + [int]($Work.Width / 2))) { $Work.Right - $Form.Width } else { $Work.Left }
+    $Y = [Math]::Max($Work.Top, [Math]::Min($Form.Top, $Work.Bottom - $Form.Height))
+    $Form.Location = New-Object System.Drawing.Point $X, $Y
+}
+
 function Place-UsageWidget($Form, [int]$Width, [int]$Height) {
-    $Work = [System.Windows.Forms.Screen]::PrimaryScreen.WorkingArea
+    $Work = (Screen-ForUsageWidget $Form).WorkingArea
+    $KeepRight = (-not $Form) -or ($Form.Left + [int]($Form.Width / 2) -ge ($Work.Left + [int]($Work.Width / 2)))
     $Form.Size = New-Object System.Drawing.Size $Width, $Height
-    $Form.Location = New-Object System.Drawing.Point (($Work.Right - $Width), ($Work.Top + 96))
+    $X = if ($KeepRight) { $Work.Right - $Width } else { $Work.Left }
+    $Y = if ($Form.Top -gt $Work.Top) { $Form.Top } else { $Work.Top + 96 }
+    $Y = [Math]::Max($Work.Top, [Math]::Min($Y, $Work.Bottom - $Height))
+    $Form.Location = New-Object System.Drawing.Point $X, $Y
 }
 
 function Toggle-UsageWidgetExpanded {
@@ -509,9 +529,43 @@ function Show-UsageWidget {
     $script:UsageExpanded = $false
     $script:UsageProviderId = [string]$script:UsageProviderId
     $script:UsageChipRects = @()
+    $script:UsageDrag = $null
     Place-UsageWidget $Form 36 168
     $Form.add_Paint({ param($Sender, $Event) Draw-UsageWidget $Event.Graphics $Sender })
-    $Form.add_MouseClick({ param($Sender, $Event) Handle-UsageWidgetClick $Event })
+    $Form.add_MouseDown({
+        param($Sender, $Event)
+        if ($Event.Button -eq [System.Windows.Forms.MouseButtons]::Left) {
+            $script:UsageDrag = [pscustomobject]@{
+                Start = $Event.Location
+                Origin = $Sender.Location
+                Moved = $false
+            }
+        }
+    })
+    $Form.add_MouseMove({
+        param($Sender, $Event)
+        if (-not $script:UsageDrag) { return }
+        $Dx = $Event.X - $script:UsageDrag.Start.X
+        $Dy = $Event.Y - $script:UsageDrag.Start.Y
+        if (-not $script:UsageDrag.Moved -and [Math]::Abs($Dx) + [Math]::Abs($Dy) -lt 6) {
+            return
+        }
+        $script:UsageDrag.Moved = $true
+        $Sender.Location = New-Object System.Drawing.Point (
+            ($script:UsageDrag.Origin.X + $Dx),
+            ($script:UsageDrag.Origin.Y + $Dy)
+        )
+    })
+    $Form.add_MouseUp({
+        param($Sender, $Event)
+        $Dragged = $script:UsageDrag -and $script:UsageDrag.Moved
+        $script:UsageDrag = $null
+        if ($Dragged) {
+            Snap-UsageWidget $Sender
+            return
+        }
+        Handle-UsageWidgetClick $Event
+    })
     $script:UsageForm = $Form
     $Form.Show()
 }

--- a/specs/ARCHITECTURE.md
+++ b/specs/ARCHITECTURE.md
@@ -113,7 +113,9 @@ The Grok adapter reads only Grok-owned session directories under `GROK_HOME`
 (default `~/.grok/sessions`). A directory is accepted only when it is owned by
 that home, is not a symlink, has a `summary.json`, and uses a bounded session
 id. Token and cache counts come from `usage.json` when present; cost is the
-Grok-recorded local estimate, not a Token Meter price-table lookup. Structural
+Grok-recorded local estimate (`costUsdTicks` at `1e10` ticks per USD), not a
+Token Meter price-table lookup. Zero, partial (`costIsPartial`), and incomplete
+(`usageIsIncomplete`) cost evidence stay unavailable rather than free. Structural
 tool names, outcomes, and turn timing come from `events.jsonl`. Sessions
 without `usage.json` remain listed with unavailable tokens and cost. The
 adapter uses a generic session title and never opens `chat_history.jsonl`,

--- a/specs/ARCHITECTURE.md
+++ b/specs/ARCHITECTURE.md
@@ -60,7 +60,7 @@ executable and import-compatibility facade; current composition lives in
 Four identities are deliberately independent:
 
 - A **runtime** produced local evidence: Claude Code, Claude Desktop, Codex,
-  Cursor, OpenCode, Kiro, or Pi.
+  Cursor, OpenCode, Kiro, Pi, Hermes, or Grok.
 - A **model provider** owns a model and its public pricing, such as Anthropic or
   OpenAI.
 - An **account provider** may expose quota information through the user's
@@ -108,6 +108,17 @@ including application-profile references, to a safe model label. Pi does not
 establish a context window size, time to first token, semantic token split, or
 cache-savings price, so those projections remain unavailable rather than being
 derived or reported as zero.
+
+The Grok adapter reads only Grok-owned session directories under `GROK_HOME`
+(default `~/.grok/sessions`). A directory is accepted only when it is owned by
+that home, is not a symlink, has a `summary.json`, and uses a bounded session
+id. Token and cache counts come from `usage.json` when present; cost is the
+Grok-recorded local estimate, not a Token Meter price-table lookup. Structural
+tool names, outcomes, and turn timing come from `events.jsonl`. Sessions
+without `usage.json` remain listed with unavailable tokens and cost. The
+adapter uses a generic session title and never opens `chat_history.jsonl`,
+`updates.jsonl`, generated titles, or session summaries. Grok sessions are
+read-only in Token Meter.
 
 ## Domain and Model Flow
 

--- a/specs/USER_GUIDE.md
+++ b/specs/USER_GUIDE.md
@@ -341,7 +341,9 @@ in its session record, never a Token Meter price-table lookup. Token Meter does
 not display Pi application-profile identifiers, and leaves Pi context pressure,
 semantic token classification, and cache savings unavailable when the trace
 does not record that evidence. Grok cost is the local estimate Grok persisted
-in `usage.json`, never a Token Meter price-table lookup.
+in `usage.json` (`costUsdTicks` at `1e10` ticks per USD), never a Token Meter
+price-table lookup. Zero, partial, or incomplete Grok cost stays unavailable
+instead of displaying as free.
 Token Meter reports recorded evidence, not a pre-flight prediction.
 
 ## Privacy

--- a/specs/USER_GUIDE.md
+++ b/specs/USER_GUIDE.md
@@ -274,9 +274,9 @@ require `sudo` or security-control changes.
 ## Data and Evidence
 
 Token Meter reads local runtime stores: JSONL traces for Claude, Codex, Cursor,
-Kiro, and Pi; read-only SQLite enrichment for Cursor, OpenCode,
-and Hermes Agent; and
-runtime-owned metadata needed to join a visible session to its trace.
+Kiro, and Pi; Grok Build session directories; read-only SQLite enrichment for
+Cursor, OpenCode, and Hermes Agent; and runtime-owned metadata needed to join a
+visible session to its trace.
 
 Discovery and parsing are runtime adapters. Operating-system paths are platform
 services. Optional enrichment falls back to the authoritative base trace when
@@ -311,6 +311,21 @@ not establish them. A provider resource identifier, such as an
 application-profile reference, is replaced with a safe generic model label;
 Token Meter does not infer or price a foundation model from it.
 
+### Grok Build sessions
+
+Grok discovery reads only Grok-owned session directories. Its default root is
+`~/.grok`; set `GROK_HOME` when Grok stores its local files elsewhere. A
+session directory must contain `summary.json` and use a bounded session id
+before Token Meter will show it. The adapter does not import cloud transcripts,
+scan arbitrary directories, or project message, reasoning, generated-title, or
+tool-payload content. It never opens `chat_history.jsonl` or `updates.jsonl`.
+
+Grok sessions use a generic content-free title. Recorded input, output, cache,
+and cost can be shown when `usage.json` is present. Tool names and turn timing
+come from `events.jsonl`. A session without persisted usage stays listed with
+unavailable tokens and cost rather than a misleading zero. Token Meter does not
+delete Grok sessions.
+
 ### Costs and estimates
 
 Token Meter uses effective-dated provider/model price periods. Reinstalling
@@ -325,7 +340,8 @@ hidden model work may be unavailable. Pi cost is the local estimate persisted
 in its session record, never a Token Meter price-table lookup. Token Meter does
 not display Pi application-profile identifiers, and leaves Pi context pressure,
 semantic token classification, and cache savings unavailable when the trace
-does not record that evidence.
+does not record that evidence. Grok cost is the local estimate Grok persisted
+in `usage.json`, never a Token Meter price-table lookup.
 Token Meter reports recorded evidence, not a pre-flight prediction.
 
 ## Privacy
@@ -376,6 +392,15 @@ is under `~/.pi/agent` or the directory named by `PI_CODING_AGENT_DIR`. Token
 Meter ignores files without a Pi session header, malformed files, symlinks, and
 cloud-only conversations. It does not need an API key or a provider account to
 read local Pi evidence.
+
+### Grok sessions do not appear
+
+Run a normal Grok Build session, then confirm that its local session directory
+is under `~/.grok/sessions` or the directory named by `GROK_HOME`. Token Meter
+ignores directories without `summary.json`, malformed files, symlinks, and
+cloud-only conversations. Sessions without `usage.json` still appear; tokens
+and cost stay unavailable until Grok persists usage. It does not need an API
+key or a provider account to read local Grok evidence.
 
 ### Source changes do not appear
 

--- a/tests/contracts/test_quota_privacy.py
+++ b/tests/contracts/test_quota_privacy.py
@@ -58,6 +58,15 @@ class QuotaPrivacyTests(unittest.TestCase):
                 opener=lambda request, timeout: _Response(oversized),
             )
 
+    def test_redirects_fail_closed_without_following(self):
+        from token_meter.quotas.common import _NoRedirectHandler
+
+        handler = _NoRedirectHandler()
+        with self.assertRaises(QuotaUnavailable) as raised:
+            handler.redirect_request(None, None, 302, "Found", {}, "https://evil.example/x")
+        self.assertEqual(str(raised.exception), "Provider quota request redirected.")
+        self.assertNotIn("evil.example", str(raised.exception))
+
     def test_unavailable_quota_is_not_reported_as_measured_zero(self):
         snapshot = quota_provider(
             "provider",

--- a/tests/contracts/test_quota_registry.py
+++ b/tests/contracts/test_quota_registry.py
@@ -34,6 +34,12 @@ class QuotaRegistryTests(unittest.TestCase):
         self.assertIs(loaders["claude"].__self__, anthropic)
         self.assertIs(loaders["codex"].__self__, openai)
 
+    def test_public_label_lookup_does_not_require_account_provider_id(self):
+        registry = QuotaRegistry((self.adapter("xai", "grok"),))
+        self.assertEqual(registry.public_ids(), ("grok",))
+        self.assertEqual(registry.label_for_public("grok"), "Xai")
+        self.assertEqual(registry.label_for_public("missing"), "Missing")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/fixtures/grok/sessions/--repo--/session-1/chat_history.jsonl
+++ b/tests/fixtures/grok/sessions/--repo--/session-1/chat_history.jsonl
@@ -1,0 +1,2 @@
+{"role":"user","content":"private grok prompt"}
+{"role":"assistant","content":"private grok response"}

--- a/tests/fixtures/grok/sessions/--repo--/session-1/events.jsonl
+++ b/tests/fixtures/grok/sessions/--repo--/session-1/events.jsonl
@@ -1,0 +1,5 @@
+{"ts":"2026-09-04T10:00:00Z","type":"turn_started","turn_number":1,"model_id":"grok-4.6"}
+{"ts":"2026-09-04T10:00:00.4Z","type":"first_token"}
+{"ts":"2026-09-04T10:00:01Z","type":"tool_started","tool_name":"read_file"}
+{"ts":"2026-09-04T10:00:02Z","type":"tool_completed","tool_name":"read_file","duration_ms":12,"outcome":"success"}
+{"ts":"2026-09-04T10:01:00Z","type":"turn_ended","outcome":"completed"}

--- a/tests/fixtures/grok/sessions/--repo--/session-1/signals.json
+++ b/tests/fixtures/grok/sessions/--repo--/session-1/signals.json
@@ -1,0 +1,8 @@
+{
+  "turnCount": 1,
+  "toolCallCount": 1,
+  "toolsUsed": ["read_file"],
+  "primaryModelId": "grok-4.6",
+  "contextTokensUsed": 115,
+  "contextWindowTokens": 200000
+}

--- a/tests/fixtures/grok/sessions/--repo--/session-1/summary.json
+++ b/tests/fixtures/grok/sessions/--repo--/session-1/summary.json
@@ -1,0 +1,9 @@
+{
+  "info": {"id": "session-1", "cwd": "/repo"},
+  "created_at": "2026-09-04T10:00:00Z",
+  "updated_at": "2026-09-04T10:01:00Z",
+  "current_model_id": "grok-4.6",
+  "generated_title": "private grok title from prompt",
+  "session_summary": "private grok summary of the user task",
+  "num_messages": 2
+}

--- a/tests/fixtures/grok/sessions/--repo--/session-1/usage.json
+++ b/tests/fixtures/grok/sessions/--repo--/session-1/usage.json
@@ -1,0 +1,30 @@
+{
+  "sessionId": "session-1",
+  "session": {
+    "inputTokens": 100,
+    "outputTokens": 20,
+    "cachedReadTokens": 10,
+    "cacheCreationTokens": 5,
+    "reasoningTokens": 4,
+    "totalTokens": 135,
+    "modelCalls": 1,
+    "costUsdTicks": 1500000000,
+    "turnCount": 1,
+    "primaryModelId": "grok-4.6"
+  },
+  "turns": [
+    {
+      "turnNumber": 1,
+      "endedAt": "2026-09-04T10:01:00Z",
+      "inputTokens": 100,
+      "outputTokens": 20,
+      "cachedReadTokens": 10,
+      "cacheCreationTokens": 5,
+      "reasoningTokens": 4,
+      "totalTokens": 135,
+      "modelCalls": 1,
+      "costUsdTicks": 1500000000,
+      "primaryModelId": "grok-4.6"
+    }
+  ]
+}

--- a/tests/integration/test_runtime_dispatch_characterization.py
+++ b/tests/integration/test_runtime_dispatch_characterization.py
@@ -10,7 +10,7 @@ class LegacyRuntimeDispatchCharacterizationTests(unittest.TestCase):
     def test_runtime_registry_has_the_current_runtimes_in_discovery_order(self):
         self.assertEqual(
             meter.runtime_registry().runtime_ids,
-            ("claude", "codex", "cursor", "opencode", "kiro", "pi", "hermes"),
+            ("claude", "codex", "cursor", "opencode", "kiro", "pi", "hermes", "grok"),
         )
         self.assertNotIsInstance(meter.runtime_registry().get("claude"), LegacyRuntimeAdapter)
         self.assertNotIsInstance(meter.runtime_registry().get("codex"), LegacyRuntimeAdapter)
@@ -19,6 +19,7 @@ class LegacyRuntimeDispatchCharacterizationTests(unittest.TestCase):
         self.assertNotIsInstance(meter.runtime_registry().get("kiro"), LegacyRuntimeAdapter)
         self.assertNotIsInstance(meter.runtime_registry().get("pi"), LegacyRuntimeAdapter)
         self.assertNotIsInstance(meter.runtime_registry().get("hermes"), LegacyRuntimeAdapter)
+        self.assertNotIsInstance(meter.runtime_registry().get("grok"), LegacyRuntimeAdapter)
 
     def test_claude_routes_through_the_native_adapter(self):
         source = {"provider": "claude", "id": "claude-session"}
@@ -97,6 +98,17 @@ class LegacyRuntimeDispatchCharacterizationTests(unittest.TestCase):
 
         adapter.load.assert_called_once()
 
+    def test_grok_routes_through_the_native_adapter(self):
+        source = {"provider": "grok", "id": "grok-session"}
+        expected = {"provider": "grok", "marker": object()}
+        adapter = mock.Mock()
+        adapter.load.return_value = expected
+
+        with mock.patch.object(meter, "_grok_native_adapter", return_value=adapter):
+            self.assertIs(meter.recompute(source), expected)
+
+        adapter.load.assert_called_once()
+
     def test_string_source_is_resolved_before_runtime_dispatch(self):
         source = {"provider": "codex", "id": "session-1"}
         expected = {"provider": "codex"}
@@ -118,7 +130,7 @@ class LegacyRuntimeDispatchCharacterizationTests(unittest.TestCase):
     def test_discovery_routes_each_runtime_once_in_registry_order(self):
         rows = {
             runtime_id: {"provider": runtime_id, "id": runtime_id + "-session"}
-            for runtime_id in ("claude", "codex", "cursor", "opencode", "kiro", "pi", "hermes")
+            for runtime_id in ("claude", "codex", "cursor", "opencode", "kiro", "pi", "hermes", "grok")
         }
         opencode_adapter = mock.Mock()
         opencode_adapter.discover_legacy.return_value = (rows["opencode"],)
@@ -134,6 +146,8 @@ class LegacyRuntimeDispatchCharacterizationTests(unittest.TestCase):
         pi_adapter.discover_legacy.return_value = (rows["pi"],)
         hermes_adapter = mock.Mock()
         hermes_adapter.discover_legacy.return_value = (rows["hermes"],)
+        grok_adapter = mock.Mock()
+        grok_adapter.discover_legacy.return_value = (rows["grok"],)
         with mock.patch.object(
             meter, "_claude_native_adapter", return_value=claude_adapter
         ), mock.patch.object(
@@ -152,12 +166,14 @@ class LegacyRuntimeDispatchCharacterizationTests(unittest.TestCase):
             meter, "_pi_native_adapter", return_value=pi_adapter
         ), mock.patch.object(
             meter, "_hermes_native_adapter", return_value=hermes_adapter
+        ), mock.patch.object(
+            meter, "_grok_native_adapter", return_value=grok_adapter
         ):
             discovered = meter.all_session_sources()
 
         self.assertEqual(discovered, [
             rows["claude"], rows["codex"], rows["cursor"], rows["opencode"], rows["kiro"],
-            rows["pi"], rows["hermes"],
+            rows["pi"], rows["hermes"], rows["grok"],
         ])
         claude_adapter.discover_legacy.assert_called_once()
         codex_adapter.discover_legacy.assert_called_once()
@@ -166,6 +182,7 @@ class LegacyRuntimeDispatchCharacterizationTests(unittest.TestCase):
         kiro_adapter.discover_legacy.assert_called_once()
         pi_adapter.discover_legacy.assert_called_once()
         hermes_adapter.discover_legacy.assert_called_once()
+        grok_adapter.discover_legacy.assert_called_once()
 
     def test_one_discovery_failure_returns_other_runtimes_and_bounded_status(self):
         codex_source = {"provider": "codex", "id": "codex-session"}
@@ -183,6 +200,8 @@ class LegacyRuntimeDispatchCharacterizationTests(unittest.TestCase):
         pi_adapter.discover_legacy.return_value = ()
         hermes_adapter = mock.Mock()
         hermes_adapter.discover_legacy.return_value = ()
+        grok_adapter = mock.Mock()
+        grok_adapter.discover_legacy.return_value = ()
         with mock.patch.object(
             meter, "_claude_native_adapter", return_value=claude_adapter
         ), mock.patch.object(
@@ -197,6 +216,8 @@ class LegacyRuntimeDispatchCharacterizationTests(unittest.TestCase):
             meter, "_pi_native_adapter", return_value=pi_adapter
         ), mock.patch.object(
             meter, "_hermes_native_adapter", return_value=hermes_adapter
+        ), mock.patch.object(
+            meter, "_grok_native_adapter", return_value=grok_adapter
         ):
             discovered = meter.all_session_sources()
 

--- a/tests/runtimes/test_grok_adapter.py
+++ b/tests/runtimes/test_grok_adapter.py
@@ -32,6 +32,7 @@ class GrokRuntimeAdapterTests(unittest.TestCase):
             loaded = adapter.load(source, DetailLevel.FULL)
 
         self.assertEqual(source.runtime_id, "grok")
+        self.assertIn("quota", GrokRuntimeAdapter.descriptor.capabilities)
         self.assertEqual(source.session_id, "session-1")
         self.assertEqual(source.display_label, "Grok")
         self.assertEqual(source.model_ref.provider_id, "xai")

--- a/tests/runtimes/test_grok_adapter.py
+++ b/tests/runtimes/test_grok_adapter.py
@@ -86,6 +86,46 @@ class GrokRuntimeAdapterTests(unittest.TestCase):
         self.assertEqual(loaded.usage.cost_usd.basis, EvidenceBasis.UNAVAILABLE)
         self.assertEqual([tool.name for tool in loaded.tools], ["read_file"])
 
+    def test_cost_ticks_use_the_documented_1e10_scale(self):
+        self.assertEqual(COST_TICKS_PER_USD, 10_000_000_000.0)
+        self.assertAlmostEqual(1500000000 / COST_TICKS_PER_USD, 0.15)
+        with tempfile.TemporaryDirectory() as tmp:
+            home = self._home(tmp)
+            usage_path = home / "sessions" / "--repo--" / "session-1" / "usage.json"
+            payload = json.loads(usage_path.read_text(encoding="utf-8"))
+            payload["session"]["costUsdTicks"] = 10_000_000_000
+            payload["turns"][0]["costUsdTicks"] = 10_000_000_000
+            usage_path.write_text(json.dumps(payload), encoding="utf-8")
+            adapter = GrokRuntimeAdapter(home)
+            loaded = adapter.load(
+                adapter.discover(DiscoveryContext(home=tmp))[0], DetailLevel.SUMMARY,
+            )
+        self.assertAlmostEqual(loaded.usage.cost_usd.value, 1.0)
+        self.assertEqual(loaded.usage.cost_usd.basis, EvidenceBasis.ESTIMATED)
+
+    def test_zero_partial_and_incomplete_cost_are_unavailable(self):
+        cases = (
+            {"costUsdTicks": 0},
+            {"costUsdTicks": 10_000_000_000, "costIsPartial": True},
+            {"costUsdTicks": 10_000_000_000, "usageIsIncomplete": True},
+        )
+        for extra in cases:
+            with self.subTest(extra=extra):
+                with tempfile.TemporaryDirectory() as tmp:
+                    home = self._home(tmp)
+                    usage_path = home / "sessions" / "--repo--" / "session-1" / "usage.json"
+                    payload = json.loads(usage_path.read_text(encoding="utf-8"))
+                    payload["session"].update(extra)
+                    payload["turns"][0].update(extra)
+                    usage_path.write_text(json.dumps(payload), encoding="utf-8")
+                    adapter = GrokRuntimeAdapter(home)
+                    loaded = adapter.load(
+                        adapter.discover(DiscoveryContext(home=tmp))[0],
+                        DetailLevel.SUMMARY,
+                    )
+                self.assertEqual(loaded.usage.cost_usd.basis, EvidenceBasis.UNAVAILABLE)
+                self.assertIsNone(loaded.usage.cost_usd.value)
+
     def test_ignores_sessions_outside_the_owned_grok_home(self):
         with tempfile.TemporaryDirectory() as tmp:
             adapter = GrokRuntimeAdapter(Path(tmp) / "empty-home")

--- a/tests/runtimes/test_grok_adapter.py
+++ b/tests/runtimes/test_grok_adapter.py
@@ -1,0 +1,139 @@
+import json
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import meter
+from token_meter.contracts import (
+    DetailLevel,
+    DiscoveryContext,
+    EvidenceBasis,
+    session_source_public_dict,
+)
+from token_meter.runtimes.grok import GrokRuntimeAdapter, COST_TICKS_PER_USD
+
+
+FIXTURES = Path(__file__).resolve().parents[1] / "fixtures" / "grok"
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class GrokRuntimeAdapterTests(unittest.TestCase):
+    def _home(self, tmp):
+        dest = Path(tmp) / ".grok"
+        shutil.copytree(FIXTURES, dest)
+        return dest
+
+    def test_normalizes_measured_tokens_and_grok_recorded_cost_without_payloads(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            adapter = GrokRuntimeAdapter(self._home(tmp))
+            source = adapter.discover(DiscoveryContext(home=tmp))[0]
+            loaded = adapter.load(source, DetailLevel.FULL)
+
+        self.assertEqual(source.runtime_id, "grok")
+        self.assertEqual(source.session_id, "session-1")
+        self.assertEqual(source.display_label, "Grok")
+        self.assertEqual(source.model_ref.provider_id, "xai")
+        self.assertEqual(source.model_ref.model_id, "grok-4.6")
+        self.assertEqual(loaded.usage.input_tokens.value, 100)
+        self.assertEqual(loaded.usage.output_tokens.value, 20)
+        self.assertEqual(loaded.usage.cache_read_tokens.value, 10)
+        self.assertEqual(loaded.usage.cache_write_tokens.value, 5)
+        self.assertAlmostEqual(loaded.usage.cost_usd.value, 1500000000 / COST_TICKS_PER_USD)
+        self.assertEqual(loaded.usage.cost_usd.basis, EvidenceBasis.ESTIMATED)
+        self.assertEqual([(tool.name, tool.status) for tool in loaded.tools], [("read_file", "success")])
+        encoded = json.dumps(session_source_public_dict(source)) + repr(loaded)
+        self.assertNotIn("private grok prompt", encoded)
+        self.assertNotIn("private grok response", encoded)
+        self.assertNotIn("private grok title from prompt", encoded)
+        self.assertNotIn("private grok summary of the user task", encoded)
+        self.assertNotIn("locator", session_source_public_dict(source))
+
+    def test_session_totals_stay_measured_when_extra_event_turns_have_no_usage(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = self._home(tmp)
+            events = home / "sessions" / "--repo--" / "session-1" / "events.jsonl"
+            events.write_text(
+                events.read_text(encoding="utf-8")
+                + json.dumps({
+                    "ts": "2026-09-04T10:02:00Z", "type": "turn_started",
+                    "turn_number": 2, "model_id": "grok-4.6",
+                }) + "\n"
+                + json.dumps({"ts": "2026-09-04T10:02:01Z", "type": "turn_ended"}) + "\n",
+                encoding="utf-8",
+            )
+            adapter = GrokRuntimeAdapter(home)
+            source = adapter.discover(DiscoveryContext(home=tmp))[0]
+            loaded = adapter.load(source, DetailLevel.SUMMARY)
+
+        self.assertEqual(loaded.usage.input_tokens.value, 100)
+        self.assertEqual(loaded.usage.output_tokens.value, 20)
+        self.assertEqual(loaded.usage.input_tokens.basis, EvidenceBasis.MEASURED)
+        self.assertAlmostEqual(loaded.usage.cost_usd.value, 1500000000 / COST_TICKS_PER_USD)
+        self.assertEqual(loaded.usage.cost_usd.basis, EvidenceBasis.ESTIMATED)
+
+    def test_missing_usage_keeps_the_session_with_unavailable_tokens(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = self._home(tmp)
+            (home / "sessions" / "--repo--" / "session-1" / "usage.json").unlink()
+            adapter = GrokRuntimeAdapter(home)
+            source = adapter.discover(DiscoveryContext(home=tmp))[0]
+            loaded = adapter.load(source, DetailLevel.SUMMARY)
+
+        self.assertEqual(source.session_id, "session-1")
+        self.assertEqual(loaded.usage.input_tokens.basis, EvidenceBasis.UNAVAILABLE)
+        self.assertEqual(loaded.usage.cost_usd.basis, EvidenceBasis.UNAVAILABLE)
+        self.assertEqual([tool.name for tool in loaded.tools], ["read_file"])
+
+    def test_ignores_sessions_outside_the_owned_grok_home(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            adapter = GrokRuntimeAdapter(Path(tmp) / "empty-home")
+            self.assertEqual(adapter.discover(DiscoveryContext(home=tmp)), ())
+
+    def test_ignores_short_session_ids_and_never_opens_chat_history(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = self._home(tmp)
+            short = home / "sessions" / "--repo--" / "short"
+            short.mkdir()
+            (short / "summary.json").write_text(
+                json.dumps({"info": {"id": "short", "cwd": "/repo"}}),
+                encoding="utf-8",
+            )
+            adapter = GrokRuntimeAdapter(home)
+            discovered = adapter.discover(DiscoveryContext(home=tmp))
+            loaded = adapter.load(discovered[0], DetailLevel.SUMMARY)
+
+        self.assertEqual([source.session_id for source in discovered], ["session-1"])
+        self.assertEqual(loaded.source.session_id, "session-1")
+
+    def test_denies_deletion_and_server_delete_before_trash(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            adapter = GrokRuntimeAdapter(self._home(tmp))
+            source = adapter.discover(DiscoveryContext(home=tmp))[0]
+            plan = adapter.deletion_plan(source)
+
+        self.assertEqual(plan.disposition.value, "deny")
+        self.assertIn("grok", meter.session_action_capability()["read_only_providers"])
+        with mock.patch.object(meter, "find_session", return_value={
+            "provider": "grok", "id": "session-1",
+        }), mock.patch.object(meter, "trash_session_log") as trash:
+            result = meter.request_session_delete("session-1")
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["error_code"], "read_only_provider")
+        self.assertIn("Grok", result["error"])
+        trash.assert_not_called()
+
+
+class GrokDocumentationTests(unittest.TestCase):
+    def test_docs_explain_grok_evidence_and_privacy_boundaries(self):
+        readme = (ROOT / "README.md").read_text()
+        guide = (ROOT / "specs" / "USER_GUIDE.md").read_text()
+        architecture = (ROOT / "specs" / "ARCHITECTURE.md").read_text()
+
+        self.assertIn("Grok Build", readme)
+        self.assertIn("GROK_HOME", guide)
+        self.assertIn("Grok Build sessions", guide)
+        self.assertIn("chat_history.jsonl", guide)
+        self.assertIn("Grok adapter", architecture)
+        self.assertIn("usage.json", architecture)

--- a/tests/test_meter.py
+++ b/tests/test_meter.py
@@ -135,6 +135,11 @@ class SourceDiscoveryCacheTests(unittest.TestCase):
                     mock.patch.object(meter, "CLAUDE_PROJECTS", str(root / "no-claude")), \
                     mock.patch.object(meter, "CURSOR_PROJECTS", str(root / "no-cursor")), \
                     mock.patch.object(meter, "OPENCODE_DB", str(root / "no-opencode.db")), \
+                    mock.patch.object(meter, "KIRO_SESSIONS", str(root / "no-kiro")), \
+                    mock.patch.object(meter, "KIRO_AGENT_STORAGE", str(root / "no-kiro-agent")), \
+                    mock.patch.object(meter, "PI_AGENT_DIR", str(root / "no-pi-agent")), \
+                    mock.patch.object(meter, "HERMES_STATE_DB", str(root / "no-hermes.db")), \
+                    mock.patch.object(meter, "GROK_HOME", str(root / "no-grok")), \
                     mock.patch.object(meter, "CLAUDE_DESKTOP_DATA_ROOTS", []), \
                     mock.patch.object(meter, "claude_desktop_index", return_value={}), \
                     mock.patch.object(meter, "_summary_cache", empty_summary_cache):
@@ -277,6 +282,7 @@ class CursorTraceTests(unittest.TestCase):
                     mock.patch.object(meter, "KIRO_AGENT_STORAGE", str(root / "no-kiro-agent")), \
                     mock.patch.object(meter, "PI_AGENT_DIR", str(root / "no-pi-agent")), \
                     mock.patch.object(meter, "HERMES_STATE_DB", str(root / "no-hermes.db")), \
+                    mock.patch.object(meter, "GROK_HOME", str(root / "no-grok")), \
                     mock.patch.object(meter, "CLAUDE_DESKTOP_DATA_ROOTS", []), \
                     mock.patch.object(meter, "claude_desktop_index", return_value={}):
                 sources = meter.all_session_sources()
@@ -6305,7 +6311,7 @@ console.log(JSON.stringify({
     def test_spend_uses_exact_calendar_ranges_and_stacked_runtime_bars(self):
         for marker in (
             "// spend-range-logic-start",
-            "const SPEND_RUNTIME_COLORS={claude:'#f26722',codex:'#04a4b0',cursor:'#a974f7',opencode:'#fa5762',kiro:'#868ec2',unknown:'#889099'};",
+            "const SPEND_RUNTIME_COLORS={claude:'#f26722',codex:'#04a4b0',cursor:'#a974f7',opencode:'#fa5762',kiro:'#868ec2',grok:'#00bceb',unknown:'#889099'};",
             "function spendRangeWindow(range,from='',to='',now=new Date())",
             "function normalizeSpendRangeChoice(value)",
             "function spendCalendarRows(days,window)",
@@ -12005,7 +12011,7 @@ class MonthlyBudgetTests(unittest.TestCase):
         self.assertEqual(stored["budgets"]["monthly_total"], 80)
         self.assertEqual(
             stored["budgets"]["allocations"],
-            {"claude": 50, "codex": 30, "cursor": 0, "opencode": 0, "kiro": 0, "pi": 0, "hermes": 0},
+            {"claude": 50, "codex": 30, "cursor": 0, "opencode": 0, "kiro": 0, "pi": 0, "hermes": 0, "grok": 0},
         )
         self.assertIn("model_pricing", stored)
 
@@ -12029,13 +12035,13 @@ class MonthlyBudgetTests(unittest.TestCase):
         self.assertEqual(loaded["monthly_total"], 0)
         self.assertEqual(
             loaded["allocations"],
-            {"claude": 0, "codex": 0, "cursor": 0, "opencode": 0, "kiro": 0, "pi": 0, "hermes": 0},
+            {"claude": 0, "codex": 0, "cursor": 0, "opencode": 0, "kiro": 0, "pi": 0, "hermes": 0, "grok": 0},
         )
         self.assertTrue(saved["ok"])
         self.assertEqual(saved["budgets"]["monthly_total"], 1490)
         self.assertEqual(
             saved["budgets"]["allocations"],
-            {"claude": 0, "codex": 1490, "cursor": 0, "opencode": 0, "kiro": 0, "pi": 0, "hermes": 0},
+            {"claude": 0, "codex": 1490, "cursor": 0, "opencode": 0, "kiro": 0, "pi": 0, "hermes": 0, "grok": 0},
         )
 
     def test_monthly_rollup_keeps_runtime_costs_and_partial_coverage(self):
@@ -12519,6 +12525,7 @@ class OpenCodeTests(unittest.TestCase):
                     mock.patch.object(meter, "KIRO_AGENT_STORAGE", str(root / "no-kiro-agent")), \
                     mock.patch.object(meter, "PI_AGENT_DIR", str(root / "no-pi-agent")), \
                     mock.patch.object(meter, "HERMES_STATE_DB", str(root / "no-hermes.db")), \
+                    mock.patch.object(meter, "GROK_HOME", str(root / "no-grok")), \
                     mock.patch.object(meter, "CLAUDE_DESKTOP_DATA_ROOTS", []), \
                     mock.patch.object(meter, "claude_desktop_index", return_value={}):
                 sources = meter.all_session_sources()

--- a/tests/test_meter.py
+++ b/tests/test_meter.py
@@ -3476,6 +3476,14 @@ class UsageWidgetTests(unittest.TestCase):
         self.assertIn("TopMost", self.windows_tray)
         self.assertIn("Get-UsageWidgetChips", self.windows_tray)
         self.assertIn("$script:UsageProviderId", self.windows_tray)
+        self.assertIn("Snap-UsageWidget", self.windows_tray)
+        self.assertIn("Screen-ForUsageWidget", self.windows_tray)
+        self.assertIn("add_MouseDown", self.windows_tray)
+        self.assertIn("isMovableByWindowBackground", self.swift)
+        self.assertIn("snapUsageWidget", self.swift)
+        self.assertIn("NSWindow.didMoveNotification", self.swift)
+        self.assertIn("_confirm_usage_widget_started", self.linux_tray)
+        self.assertIn("usage widget failed to start", self.linux_tray)
 
     def test_linux_tray_does_not_embed_webkit_or_auto_open_a_widget_window(self):
         self.assertNotIn("WebKit2", self.linux_tray)

--- a/tests/test_meter.py
+++ b/tests/test_meter.py
@@ -3417,6 +3417,7 @@ class SelectedSessionStateCacheTests(unittest.TestCase):
 class SessionRouteTests(unittest.TestCase):
     def test_dashboard_accepts_root_and_unique_session_paths(self):
         self.assertTrue(meter.is_dashboard_page_path("/"))
+        self.assertTrue(meter.is_dashboard_page_path("/widget"))
         self.assertTrue(meter.is_dashboard_page_path("/sessions/019f16fa-dc6c-7a62-839c-25c15dca4e75"))
         self.assertTrue(meter.is_dashboard_page_path("/sessions/claude%20session/"))
 
@@ -3425,6 +3426,249 @@ class SessionRouteTests(unittest.TestCase):
         self.assertFalse(meter.is_dashboard_page_path("/sessions/"))
         self.assertFalse(meter.is_dashboard_page_path("/sessions/one/two"))
 
+
+class UsageWidgetTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        root = Path(meter.__file__).resolve().parent
+        cls.root = root
+        cls.page = (root / "page.html").read_text()
+        cls.swift = (root / "menubar" / "TokenMeterMenuBar.swift").read_text()
+        cls.linux_tray = (root / "menubar" / "token_meter_tray.py").read_text()
+        cls.linux_widget = (root / "menubar" / "token_meter_widget.py").read_text()
+        cls.windows_tray = (root / "scripts" / "run-tray.ps1").read_text()
+        cls.manifest = (root / "runtime-manifest.txt").read_text()
+
+    def test_dashboard_drawer_reads_menubar_quotas_and_recent_sessions(self):
+        for marker in (
+            'id=usage-widget',
+            'id=usage-widget-tab',
+            'id=usage-widget-panel',
+            'id=usage-widget-chips',
+            "fetch('/menubar'",
+            'provider_quotas',
+            'recent_sessions',
+            "h==='widget'",
+            'usageWidgetStandalone',
+            'usageWidgetChips',
+            'used_percent',
+        ):
+            self.assertIn(marker, self.page)
+        self.assertNotIn("user_message", self.page.split("id=usage-widget")[1][:4000])
+
+    def test_native_companions_open_the_usage_widget(self):
+        self.assertIn('NSMenuItem(title: "Usage widget"', self.swift)
+        self.assertIn("#selector(toggleUsageWidget)", self.swift)
+        self.assertIn("http://127.0.0.1:8722/#widget", self.swift)
+        self.assertIn("WKWebView", self.swift)
+        self.assertIn("Usage widget", self.linux_tray)
+        self.assertIn("token_meter_widget.py", self.linux_tray)
+        self.assertIn("spawn_usage_widget", self.linux_tray)
+        self.assertIn('CheckMenuItem(label="Usage widget"', self.linux_tray)
+        self.assertIn("usage_widget_open", self.linux_tray)
+        self.assertIn("_start_usage_widget", self.linux_tray)
+        self.assertIn("--quit", self.linux_tray)
+        self.assertIn("Hide-UsageWidget", self.windows_tray)
+        self.assertIn("CheckOnClick", self.windows_tray)
+        self.assertIn("usageWidgetOpenDefaultsKey", self.swift)
+        self.assertIn("showUsageWidget()", self.swift)
+        self.assertIn("Usage widget", self.windows_tray)
+        self.assertIn("TopMost", self.windows_tray)
+        self.assertIn("Get-UsageWidgetChips", self.windows_tray)
+        self.assertIn("$script:UsageProviderId", self.windows_tray)
+
+    def test_linux_tray_does_not_embed_webkit_or_auto_open_a_widget_window(self):
+        self.assertNotIn("WebKit2", self.linux_tray)
+        self.assertNotIn("UsageWidgetWindow", self.linux_tray)
+        self.assertNotIn("GLib.idle_add(self.show_usage_widget)", self.linux_tray)
+        self.assertNotIn("webkit", self.linux_tray.lower())
+
+    def test_linux_desktop_widget_is_a_single_instance_native_process(self):
+        self.assertIn("com.tokenmeter.usagewidget", self.linux_widget)
+        self.assertIn("Gtk.Application", self.linux_widget)
+        self.assertIn("usage_widget_chips", self.linux_widget)
+        self.assertIn("usage_widget_view", self.linux_widget)
+        self.assertIn("usage_widget_frame", self.linux_widget)
+        self.assertIn("usage_widget_snap", self.linux_widget)
+        self.assertIn("begin_move_drag", self.linux_widget)
+        self.assertIn("set_override_redirect", self.linux_widget)
+        self.assertIn("size-allocate", self.linux_widget)
+        self.assertIn("_pin_drawn_size", self.linux_widget)
+        self.assertNotIn("WebKit2", self.linux_widget)
+        self.assertNotIn("webkit", self.linux_widget.lower())
+        self.assertIn("required menubar/token_meter_widget.py", self.manifest)
+
+
+class WidgetLogicTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        import importlib.util
+        widget_path = Path(meter.__file__).with_name("menubar").joinpath(
+            "token_meter_widget.py"
+        )
+        spec = importlib.util.spec_from_file_location("token_meter_widget", widget_path)
+        cls.widget = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(cls.widget)
+        cls.sample = {
+            "provider": "grok",
+            "source": {"label": "Grok"},
+            "ended": False,
+            "runtime_catalog": {
+                "claude": {"label": "Claude"},
+                "codex": {"label": "Codex"},
+                "cursor": {"label": "Cursor"},
+                "grok": {"label": "Grok"},
+                "unknown-runtime": {"label": "Unknown"},
+            },
+            "provider_quotas": [
+                {
+                    "id": "claude", "label": "Claude", "status": "ok",
+                    "windows": [
+                        {"label": "Session", "used_percent": 4},
+                        {"label": "Weekly", "used_percent": 17},
+                    ],
+                },
+                {
+                    "id": "codex", "label": "Codex", "status": "ok",
+                    "windows": [{"label": "Session", "used_percent": 0}],
+                },
+                {"id": "cursor", "label": "Cursor", "status": "error", "windows": []},
+            ],
+            "recent_sessions": [
+                {"id": "g1", "provider": "grok", "label": "Grok", "name": "Draft"},
+                {"id": "c1", "provider": "claude", "label": "Claude Code", "name": "Plan"},
+            ],
+            "live_throughput": {"available": True, "output_tps": 2.5},
+        }
+
+    def test_chips_come_from_quotas_and_sessions_not_a_hardcoded_runtime_list(self):
+        chips = self.widget.usage_widget_chips(self.sample)
+        self.assertEqual([row["id"] for row in chips], ["claude", "codex", "cursor", "grok"])
+        self.assertEqual(chips[0]["label"], "Claude")
+        self.assertEqual(chips[-1]["label"], "Grok")
+        self.assertTrue(chips[0]["has_quota"])
+        self.assertFalse(chips[-1]["has_quota"])
+        self.assertNotIn("unknown-runtime", [row["id"] for row in chips])
+        self.assertNotIn("if provider ==", Path(self.widget.__file__).read_text())
+
+    def test_selected_runtime_filters_quotas_and_sessions(self):
+        overview = self.widget.usage_widget_view(self.sample, "")
+        self.assertEqual(overview["title"], "Claude")
+        self.assertEqual(overview["hottest"], 17)
+        self.assertTrue(overview["quota_available"])
+        self.assertEqual([row["id"] for row in overview["sessions"]], ["g1", "c1"])
+        self.assertEqual(overview["live_tps"], 2.5)
+
+        grok = self.widget.usage_widget_view(self.sample, "grok")
+        self.assertEqual(grok["title"], "Grok")
+        self.assertEqual(grok["windows"], [])
+        self.assertFalse(grok["quota_available"])
+        self.assertIsNone(grok["hottest"])
+        self.assertEqual([row["id"] for row in grok["sessions"]], ["g1"])
+        self.assertEqual(grok["live_tps"], 2.5)
+
+        claude = self.widget.usage_widget_view(self.sample, "claude")
+        self.assertEqual(len(claude["windows"]), 2)
+        self.assertEqual([row["id"] for row in claude["sessions"]], ["c1"])
+        self.assertIsNone(claude["live_tps"])
+
+    def test_unknown_selection_falls_back_to_all(self):
+        view = self.widget.usage_widget_view(self.sample, "missing")
+        self.assertEqual(view["selected_id"], "")
+        self.assertEqual(view["title"], "Claude")
+
+    def test_default_frame_docks_to_the_right_edge(self):
+        frame = self.widget.usage_widget_frame(False, None, (0, 0, 1920, 1080))
+        self.assertEqual((frame["width"], frame["height"]), (36, 168))
+        self.assertEqual(frame["x"], 1920 - 36)
+        self.assertEqual(frame["y"], 96)
+        self.assertEqual(frame["anchor"], "right")
+
+    def test_expanding_keeps_the_right_edge_fixed(self):
+        collapsed = self.widget.usage_widget_frame(False, None, (100, 50, 1600, 900))
+        saved = {
+            "x": collapsed["x"], "y": collapsed["y"],
+            "width": collapsed["width"], "anchor": "right",
+        }
+        expanded = self.widget.usage_widget_frame(True, saved, (100, 50, 1600, 900))
+        self.assertEqual(expanded["x"] + expanded["width"], collapsed["x"] + collapsed["width"])
+        self.assertGreater(expanded["width"], collapsed["width"])
+        self.assertEqual(expanded["y"], collapsed["y"])
+
+    def test_drop_snaps_to_the_nearer_vertical_edge(self):
+        monitor = (100, 50, 1600, 900)
+        left = self.widget.usage_widget_snap(180, 200, 36, 168, monitor)
+        right = self.widget.usage_widget_snap(1400, 200, 36, 168, monitor)
+        self.assertEqual(left["anchor"], "left")
+        self.assertEqual(left["x"], 100)
+        self.assertEqual(left["y"], 200)
+        self.assertEqual(right["anchor"], "right")
+        self.assertEqual(right["x"], 100 + 1600 - 36)
+        self.assertEqual(right["y"], 200)
+
+    def test_left_dock_opens_outward_and_right_dock_keeps_the_wall(self):
+        monitor = (0, 0, 1920, 1080)
+        left = self.widget.usage_widget_frame(
+            True, {"x": 0, "y": 180, "width": 36, "anchor": "left"}, monitor,
+        )
+        self.assertEqual(left["anchor"], "left")
+        self.assertEqual(left["x"], 0)
+        self.assertGreater(left["width"], 36)
+        right_collapsed = self.widget.usage_widget_frame(False, None, monitor)
+        right = self.widget.usage_widget_frame(True, right_collapsed, monitor)
+        self.assertEqual(right["x"] + right["width"], 1920)
+
+    def test_right_snap_uses_the_drawn_width_so_it_is_not_clipped(self):
+        monitor = (1080, 0, 3440, 1440)
+        snapped = self.widget.usage_widget_snap(4300, 200, 395, 168, monitor)
+        self.assertEqual(snapped["anchor"], "right")
+        self.assertEqual(snapped["x"] + 395, 1080 + 3440)
+        self.assertEqual(
+            self.widget.usage_widget_dock_x("right", 395, monitor) + 395,
+            1080 + 3440,
+        )
+
+    def test_expanded_size_includes_panel_side_margins(self):
+        width, _height = self.widget.usage_widget_size(True)
+        self.assertEqual(
+            width,
+            self.widget.COLLAPSED_SIZE[0]
+            + self.widget.EXPANDED_SIZE[0]
+            + 2 * self.widget.PANEL_MARGIN_X,
+        )
+
+    def test_right_snap_is_flush_on_every_monitor(self):
+        monitors = (
+            (1080, 1440, 3440, 1440),
+            (0, 626, 1080, 2560),
+            (1080, 0, 3440, 1440),
+        )
+        for monitor in monitors:
+            mx, my, mw, _mh = monitor
+            for width in (36, 360, 395):
+                snapped = self.widget.usage_widget_snap(
+                    mx + mw - 12, my + 80, width, 168, monitor,
+                )
+                self.assertEqual(snapped["anchor"], "right", (monitor, width))
+                self.assertEqual(snapped["x"] + width, mx + mw, (monitor, width))
+                self.assertEqual(
+                    self.widget.usage_widget_dock_x("right", width, monitor) + width,
+                    mx + mw,
+                    (monitor, width),
+                )
+
+    def test_shrinking_while_right_docked_does_not_leave_a_gap(self):
+        monitor = (0, 0, 1920, 1080)
+        wide = self.widget.usage_widget_frame(
+            True, {"x": 1584, "y": 96, "width": 336, "anchor": "right"}, monitor,
+        )
+        thin = self.widget.usage_widget_frame(False, wide, monitor)
+        self.assertEqual(thin["anchor"], "right")
+        self.assertEqual(thin["x"] + thin["width"], 1920)
+        self.assertEqual(thin["y"], wide["y"])
+
+
+class SessionRouteAssetTests(unittest.TestCase):
     def test_dashboard_serves_only_explicitly_bundled_assets(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -8884,6 +9128,26 @@ class TrayLogicTests(unittest.TestCase):
         self.assertIn("12.3 tok/s", title)
         self.assertIn("Claude 88% · weekly", title)
 
+    def test_spawn_usage_widget_starts_a_separate_process(self):
+        with mock.patch.object(self.tray.subprocess, "Popen") as popen:
+            self.tray.spawn_usage_widget()
+        command = popen.call_args[0][0]
+        self.assertEqual(command[0], self.tray.sys.executable)
+        self.assertTrue(command[-1].endswith("token_meter_widget.py"))
+        self.assertTrue(popen.call_args.kwargs.get("start_new_session"))
+
+    def test_spawn_usage_widget_can_quit_the_existing_process(self):
+        with mock.patch.object(self.tray, "usage_widget_pid", return_value=4321):
+            with mock.patch.object(self.tray.os, "kill") as kill:
+                self.tray.spawn_usage_widget(["--quit"])
+        kill.assert_called_once_with(4321, self.tray.signal.SIGTERM)
+
+    def test_spawn_usage_widget_skips_during_smoke(self):
+        with mock.patch.dict(os.environ, {"TOKEN_METER_TRAY_SMOKE": "1"}):
+            with mock.patch.object(self.tray.subprocess, "Popen") as popen:
+                self.tray.spawn_usage_widget()
+        popen.assert_not_called()
+
     def test_budget_notifications_fire_on_threshold_crossing(self):
         budget = {
             "configured": True,
@@ -8940,6 +9204,7 @@ class TraySourceTests(unittest.TestCase):
         for marker in (
             '("overview", "All")',
             '("claude", "Claude")',
+            '("grok", "Grok")',
             "Menu bar title",
             "Quota notifications",
             "Warn at",
@@ -9077,6 +9342,39 @@ class ProviderQuotaTests(unittest.TestCase):
                          ["Session", "Sonnet weekly"])
         self.assertIn("Weekly limit was not reported by Claude", result["coverage_note"])
 
+    def test_claude_fable_scoped_weekly_is_not_the_main_weekly_duplicate(self):
+        now = 1_000_000.0
+        result = meter.parse_claude_quota({
+            "five_hour": {"utilization": 17, "resets_at": now + 3600},
+            "seven_day": {"utilization": 20, "resets_at": now + 7200},
+            "limits": [
+                {
+                    "kind": "session", "group": "session", "percent": 17,
+                    "is_active": False, "resets_at": now + 3600, "scope": None,
+                },
+                {
+                    "kind": "weekly_all", "group": "weekly", "percent": 20,
+                    "is_active": True, "resets_at": now + 7200, "scope": None,
+                },
+                {
+                    "kind": "weekly_scoped", "group": "weekly", "percent": 1,
+                    "is_active": False, "resets_at": now + 7200,
+                    "scope": {
+                        "model": {"id": None, "display_name": "Fable"},
+                        "surface": None,
+                    },
+                },
+            ],
+        }, credentials={"subscriptionType": "max"}, now=now)
+
+        labels = [row["label"] for row in result["windows"]]
+        self.assertEqual(labels, ["Session", "Weekly", "Fable weekly"])
+        self.assertEqual(
+            [row["used_percent"] for row in result["windows"]],
+            [17.0, 20.0, 1.0],
+        )
+        self.assertNotIn("Scoped 2 weekly", labels)
+
     def test_third_party_claude_auth_is_explicitly_unavailable(self):
         with mock.patch.object(meter, "claude_auth_status", return_value={
             "loggedIn": True, "authMethod": "third_party", "apiProvider": "bedrock",
@@ -9089,6 +9387,125 @@ class ProviderQuotaTests(unittest.TestCase):
         self.assertIn("not exposed", result["error"])
         self.assertIn("Session and Weekly limits were not reported by Claude",
                       result["coverage_note"])
+
+    def test_grok_parser_maps_weekly_credit_pool_without_inventing_session_limits(self):
+        now = 1_789_080_000.0
+        result = meter.parse_grok_quota({
+            "config": {
+                "currentPeriod": {
+                    "type": "USAGE_PERIOD_TYPE_WEEKLY",
+                    "start": "2026-09-06T22:43:54+00:00",
+                    "end": "2026-09-13T22:43:54+00:00",
+                },
+                "creditUsagePercent": 22.0,
+                "onDemandCap": {"val": 0},
+                "onDemandUsed": {"val": 0},
+                "productUsage": [{"product": "GrokBuild", "usagePercent": 22.0}],
+                "billingPeriodStart": "2026-09-06T22:43:54+00:00",
+                "billingPeriodEnd": "2026-09-13T22:43:54+00:00",
+            },
+        }, now=now)
+
+        self.assertEqual(result["status"], "ok")
+        self.assertEqual(result["id"], "grok")
+        self.assertEqual(result["plan"], "Grok Build")
+        self.assertEqual([row["label"] for row in result["windows"]], ["Weekly"])
+        self.assertAlmostEqual(result["windows"][0]["used_percent"], 22.0)
+        self.assertEqual(result["windows"][0]["kind"], "weekly")
+        self.assertEqual(result["windows"][0]["window_seconds"], 7 * 24 * 60 * 60)
+        self.assertIn("Session limit was not reported by Grok", result["coverage_note"])
+        self.assertNotIn("email", json.dumps(result))
+
+    def test_grok_parser_adds_on_demand_and_extra_products(self):
+        result = meter.parse_grok_quota({
+            "config": {
+                "currentPeriod": {"type": "USAGE_PERIOD_TYPE_WEEKLY"},
+                "creditUsagePercent": 10,
+                "productUsage": [
+                    {"product": "GrokBuild", "usagePercent": 10},
+                    {"product": "Imagine", "usagePercent": 40},
+                ],
+                "onDemandCap": {"val": 100},
+                "onDemandUsed": {"val": 25},
+            },
+        }, now=1_000_000)
+
+        self.assertEqual(
+            [row["label"] for row in result["windows"]],
+            ["Weekly", "Imagine", "On-demand"],
+        )
+        self.assertAlmostEqual(result["windows"][-1]["used_percent"], 25.0)
+
+    def test_missing_grok_auth_is_unavailable_not_zero(self):
+        with mock.patch.object(meter, "GROK_AUTH", "/tmp/missing-grok-auth.json"):
+            with self.assertRaises(meter.QuotaUnavailable) as raised:
+                meter.grok_oauth_token(now=1_000_000)
+        self.assertIn("not signed in", str(raised.exception))
+        self.assertNotIn("Bearer", str(raised.exception))
+
+    def test_expired_grok_auth_asks_for_refresh_without_leaking_credentials(self):
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
+            json.dump({
+                "https://auth.x.ai::example": {
+                    "key": "expired-token",
+                    "expires_at": 1_000_000,
+                    "email": "secret@example.test",
+                },
+            }, handle)
+            path = handle.name
+        try:
+            with mock.patch.object(meter, "GROK_AUTH", path):
+                with self.assertRaises(meter.QuotaUnavailable) as raised:
+                    meter.grok_oauth_token(now=1_000_120)
+            self.assertIn("refreshed", str(raised.exception))
+            self.assertNotIn("expired-token", str(raised.exception))
+            self.assertNotIn("secret@example.test", str(raised.exception))
+        finally:
+            os.unlink(path)
+
+    def test_grok_quota_loader_uses_local_sign_in_and_bounded_billing_url(self):
+        captured = {}
+
+        class Response:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def read(self, size=-1):
+                payload = json.dumps({
+                    "config": {
+                        "creditUsagePercent": 5,
+                        "currentPeriod": {"type": "USAGE_PERIOD_TYPE_WEEKLY"},
+                    },
+                }).encode()
+                return payload[:size] if size >= 0 else payload
+
+        def opener(request, timeout=None):
+            captured["url"] = request.full_url
+            captured["authorization"] = request.get_header("Authorization")
+            return Response()
+
+        with mock.patch.object(meter, "grok_oauth_token", return_value="local-token"):
+            result = meter.load_grok_quota(now=1_000_000, opener=opener)
+
+        self.assertEqual(captured["url"], "https://cli-chat-proxy.grok.com/v1/billing?format=credits")
+        self.assertEqual(captured["authorization"], "Bearer local-token")
+        self.assertEqual(result["windows"][0]["used_percent"], 5.0)
+
+    def test_quota_snapshots_follow_the_registry_including_grok(self):
+        meter.reset_provider_quota_cache()
+        self.assertEqual(
+            meter.quota_registry().public_ids(),
+            ("claude", "codex", "cursor", "grok"),
+        )
+        rows = meter.provider_quota_snapshots(
+            now=1_000_000, loaders={"grok": mock.Mock()}, start_refresh=False,
+        )
+        self.assertEqual([row["id"] for row in rows], ["grok"])
+        self.assertEqual(rows[0]["label"], "Grok")
+        self.assertEqual(rows[0]["status"], "loading")
 
     def test_cursor_parser_labels_monthly_individual_cap(self):
         now = 1_000_000.0

--- a/token_meter/app.py
+++ b/token_meter/app.py
@@ -186,6 +186,10 @@ from token_meter.runtimes.hermes import (
     HermesRuntimeAdapter,
     HermesRuntimeAdapterProxy,
 )
+from token_meter.runtimes.grok import (
+    GrokRuntimeAdapter,
+    GrokRuntimeAdapterProxy,
+)
 from token_meter.runtimes.path_cache import BoundedPathCache
 from token_meter.runtimes.registry import RuntimeRegistry
 from token_meter.mcp.service import MCPQueryService
@@ -247,6 +251,11 @@ KIRO_AGENT_STORAGE = _default_kiro_agent_storage_root(
 PI_AGENT_DIR = os.path.abspath(os.path.expanduser(
     os.environ.get("PI_CODING_AGENT_DIR", "~/.pi/agent")
 ))
+GROK_HOME = os.path.abspath(os.path.expanduser(
+    os.environ.get("GROK_HOME", "~/.grok")
+))
+
+
 def hermes_state_db_path(environ=None):
     environ = os.environ if environ is None else environ
     state_db = str(environ.get("HERMES_STATE_DB") or "").strip()
@@ -295,7 +304,7 @@ SESSION_CLAUDE_MODEL_ID_RE = re.compile(
     re.IGNORECASE,
 )
 HERMES_MODEL_IDENTITY_LABEL = "Bedrock application profile"
-BUDGET_PROVIDERS = ("claude", "codex", "cursor", "opencode", "kiro", "pi", "hermes")
+BUDGET_PROVIDERS = ("claude", "codex", "cursor", "opencode", "kiro", "pi", "hermes", "grok")
 DEFAULT_RUNTIME_BUDGET = 0.0
 DEFAULT_BUDGET_THRESHOLDS = (80, 90, 100)
 DEFAULT_SESSION_BUDGET = 10.0
@@ -2847,6 +2856,44 @@ def recompute_hermes(source):
     return _hermes_native_adapter().recompute_legacy(source)
 
 
+_grok_native_adapters = {}
+
+
+def _grok_compatibility():
+    return _pi_compatibility()
+
+
+def _grok_adapter_for(grok_home=None):
+    path = os.path.abspath(os.path.expanduser(grok_home or GROK_HOME))
+    adapter = _grok_native_adapters.get(path)
+    if adapter is None:
+        adapter = GrokRuntimeAdapter(
+            path,
+            project_resolver=home_shorten,
+            compatibility=_grok_compatibility(),
+        )
+        _grok_native_adapters[path] = adapter
+        if len(_grok_native_adapters) > 8:
+            oldest = next(iter(_grok_native_adapters))
+            if oldest != path:
+                _grok_native_adapters.pop(oldest, None)
+    return adapter
+
+
+def _grok_native_adapter():
+    return _grok_adapter_for()
+
+
+def grok_session_sources(grok_home=None):
+    return list(_grok_adapter_for(grok_home).discover_legacy(
+        DiscoveryContext(home=os.path.expanduser("~"))
+    ))
+
+
+def recompute_grok(source):
+    return _grok_native_adapter().recompute_legacy(source)
+
+
 def opencode_db_path():
     path = os.path.expanduser(OPENCODE_DB)
     return path if os.path.isabs(path) else os.path.join(OPENCODE_DATA_ROOT, path)
@@ -4877,6 +4924,7 @@ def runtime_registry():
                 KiroRuntimeAdapterProxy(lambda: _kiro_native_adapter()),
                 PiRuntimeAdapterProxy(lambda: _pi_native_adapter()),
                 HermesRuntimeAdapterProxy(lambda: _hermes_native_adapter()),
+                GrokRuntimeAdapterProxy(lambda: _grok_native_adapter()),
             ))
     return _RUNTIME_REGISTRY
 
@@ -5976,7 +6024,7 @@ def session_action_capability():
         "token": _ACTION_TOKEN,
         "recoverable": True,
         "destination": trash_plan.destination_label,
-        "read_only_providers": ["opencode", "hermes"],
+        "read_only_providers": ["opencode", "hermes", "grok"],
     }
 
 
@@ -7478,6 +7526,8 @@ def _source_inventory_roots():
         KIRO_AGENT_STORAGE,
         PI_AGENT_DIR,
         os.path.join(PI_AGENT_DIR, "sessions"),
+        GROK_HOME,
+        os.path.join(GROK_HOME, "sessions"),
     )
 
 

--- a/token_meter/app.py
+++ b/token_meter/app.py
@@ -147,6 +147,7 @@ from token_meter.quotas.common import (
 )
 from token_meter.quotas import cursor as cursor_quotas
 from token_meter.quotas import openai as openai_quotas
+from token_meter.quotas import xai as xai_quotas
 from token_meter.quotas.registry import QuotaRegistry
 from token_meter.runtimes.cursor import (
     CursorRuntimeAdapter,
@@ -254,6 +255,7 @@ PI_AGENT_DIR = os.path.abspath(os.path.expanduser(
 GROK_HOME = os.path.abspath(os.path.expanduser(
     os.environ.get("GROK_HOME", "~/.grok")
 ))
+GROK_AUTH = os.path.join(GROK_HOME, "auth.json")
 
 
 def hermes_state_db_path(environ=None):
@@ -8688,10 +8690,28 @@ def load_cursor_quota(now=None, opener=None):
     )
 
 
+def grok_oauth_token(now=None):
+    return xai_quotas.oauth_token(GROK_AUTH, now=now)
+
+
+def parse_grok_quota(payload, now=None):
+    return xai_quotas.parse_quota(payload, now=now)
+
+
+def load_grok_quota(now=None, opener=None):
+    return xai_quotas.load_quota(
+        grok_oauth_token, quota_http_json, now=now, opener=opener
+    )
+
+
+def _quota_label(provider):
+    return quota_registry().label_for_public(provider)
+
+
 def _quota_loading_row(provider):
-    labels = {"claude": "Claude", "codex": "Codex", "cursor": "Cursor"}
     return quota_provider(
-        provider, labels[provider], "loading", "Provider account", error="Loading provider quotas.",
+        provider, _quota_label(provider), "loading", "Provider account",
+        error="Loading provider quotas.",
     )
 
 
@@ -8704,8 +8724,9 @@ def _quota_failure_row(provider, error, now):
         previous["error"] = compact_text(safe_error, 180)
         previous["attempted_at"] = now
         return previous
-    labels = {"claude": "Claude", "codex": "Codex", "cursor": "Cursor"}
-    row = quota_provider(provider, labels[provider], "error", "Provider account", error=safe_error)
+    row = quota_provider(
+        provider, _quota_label(provider), "error", "Provider account", error=safe_error,
+    )
     row["fetched_at"] = now
     row["attempted_at"] = now
     return row
@@ -8753,6 +8774,10 @@ def quota_registry():
                     "cursor", "cursor", "Cursor",
                     lambda now=None: load_cursor_quota(now=now),
                 ),
+                CallableQuotaAdapter(
+                    "xai", "grok", "Grok",
+                    lambda now=None: load_grok_quota(now=now),
+                ),
             ))
     return _QUOTA_REGISTRY
 
@@ -8777,9 +8802,7 @@ def provider_quota_snapshots(now=None, loaders=None, start_refresh=True):
         ).start()
 
     out = []
-    for provider in ("claude", "codex", "cursor"):
-        if provider not in loaders:
-            continue
+    for provider in loaders:
         row = cached_rows.get(provider) or _quota_loading_row(provider)
         fetched_at = quota_timestamp(row.get("fetched_at"))
         age = max(0.0, now - fetched_at) if fetched_at is not None else None
@@ -9239,7 +9262,9 @@ def page_path():
 
 
 def is_dashboard_page_path(req_path):
-    return req_path == "/" or bool(re.fullmatch(r"/sessions/[^/]{1,240}/?", req_path or ""))
+    return req_path in ("/", "/widget") or bool(
+        re.fullmatch(r"/sessions/[^/]{1,240}/?", req_path or "")
+    )
 
 
 _DASHBOARD_ASSETS = {

--- a/token_meter/quotas/anthropic.py
+++ b/token_meter/quotas/anthropic.py
@@ -51,9 +51,7 @@ def parse_quota(payload, credentials=None, now=None):
             field, payload.get(field), "weekly", label, 7 * 24 * 60 * 60, now=now
         ))
     for index, limit in enumerate(payload.get("limits") or []):
-        if not isinstance(limit, dict) or limit.get("is_active") is False:
-            continue
-        if limit.get("kind") != "weekly_scoped" and limit.get("group") != "weekly":
+        if not isinstance(limit, dict) or limit.get("kind") != "weekly_scoped":
             continue
         scope = limit.get("scope") if isinstance(limit.get("scope"), dict) else {}
         model = scope.get("model") if isinstance(scope.get("model"), dict) else {}

--- a/token_meter/quotas/common.py
+++ b/token_meter/quotas/common.py
@@ -6,7 +6,7 @@ import math
 import re
 import time
 from urllib.error import HTTPError, URLError
-from urllib.request import Request, urlopen
+from urllib.request import HTTPHandler, HTTPSHandler, HTTPRedirectHandler, Request, build_opener
 
 from .base import QuotaUnavailable
 
@@ -170,10 +170,19 @@ def quota_slug(value):
     return slug[:64] or "quota"
 
 
+class _NoRedirectHandler(HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        raise QuotaUnavailable("Provider quota request redirected.")
+
+
+def _quota_opener():
+    return build_opener(_NoRedirectHandler, HTTPHandler, HTTPSHandler)
+
+
 def quota_http_json(url, headers=None, timeout=DEFAULT_HTTP_TIMEOUT_S, opener=None):
     request = Request(url, headers=headers or {}, method="GET")
     try:
-        response = (opener or urlopen)(request, timeout=timeout)
+        response = (opener or _quota_opener().open)(request, timeout=timeout)
         with response:
             raw = response.read(MAX_RESPONSE_BYTES + 1)
         if len(raw) > MAX_RESPONSE_BYTES:
@@ -182,6 +191,8 @@ def quota_http_json(url, headers=None, timeout=DEFAULT_HTTP_TIMEOUT_S, opener=No
         if not isinstance(value, dict):
             raise QuotaUnavailable("Provider returned an invalid quota response.")
         return value
+    except QuotaUnavailable:
+        raise
     except HTTPError as exc:
         code = exc.code
         exc.close()

--- a/token_meter/quotas/registry.py
+++ b/token_meter/quotas/registry.py
@@ -41,3 +41,12 @@ class QuotaRegistry:
             adapter.public_id: adapter.load
             for adapter in self._ordered
         }
+
+    def public_ids(self):
+        return tuple(adapter.public_id for adapter in self._ordered)
+
+    def label_for_public(self, public_id):
+        adapter = self._by_public.get(public_id)
+        if adapter is None:
+            return str(public_id or "Provider").title()
+        return adapter.label

--- a/token_meter/quotas/xai.py
+++ b/token_meter/quotas/xai.py
@@ -1,0 +1,134 @@
+"""xAI / Grok Build account quota parsing and bounded acquisition."""
+
+import json
+import time
+
+from .base import QuotaUnavailable
+from .common import (
+    quota_coverage_note,
+    quota_number,
+    quota_provider,
+    quota_slug,
+    quota_timestamp,
+    quota_window,
+)
+
+
+BILLING_URL = "https://cli-chat-proxy.grok.com/v1/billing?format=credits"
+PERIOD_KINDS = {
+    "USAGE_PERIOD_TYPE_WEEKLY": ("weekly", "Weekly"),
+    "USAGE_PERIOD_TYPE_MONTHLY": ("monthly", "Monthly"),
+}
+
+
+def _money_val(value):
+    if isinstance(value, dict):
+        return quota_number(value.get("val") if "val" in value else value.get("value"))
+    return quota_number(value)
+
+
+def oauth_token(auth_path, now=None):
+    try:
+        with open(auth_path, encoding="utf-8") as stream:
+            data = json.load(stream)
+    except (FileNotFoundError, OSError, json.JSONDecodeError):
+        raise QuotaUnavailable("Grok is not signed in locally.") from None
+    if not isinstance(data, dict):
+        raise QuotaUnavailable("Grok is not signed in locally.")
+    current = float(now if now is not None else time.time())
+    expired = False
+    for value in data.values():
+        if not isinstance(value, dict):
+            continue
+        token = str(value.get("key") or "").strip()
+        if not token:
+            continue
+        expires_at = quota_timestamp(value.get("expires_at"))
+        if expires_at is not None and expires_at <= current + 60:
+            expired = True
+            continue
+        return token
+    if expired:
+        raise QuotaUnavailable("Grok authentication needs to be refreshed.")
+    raise QuotaUnavailable("Grok is not signed in locally.")
+
+
+def parse_quota(payload, now=None):
+    root = payload.get("config") if isinstance(payload.get("config"), dict) else payload
+    if not isinstance(root, dict):
+        root = {}
+    period = root.get("currentPeriod") if isinstance(root.get("currentPeriod"), dict) else {}
+    period_type = str(period.get("type") or "")
+    kind, label = PERIOD_KINDS.get(period_type, ("extra", "Usage"))
+    start = quota_timestamp(period.get("start") or root.get("billingPeriodStart"))
+    end = quota_timestamp(period.get("end") or root.get("billingPeriodEnd"))
+    duration = end - start if start is not None and end is not None and end > start else None
+    if duration is None and kind == "weekly":
+        duration = 7 * 24 * 60 * 60
+    if duration is None and kind == "monthly":
+        duration = 30 * 24 * 60 * 60
+    windows, seen = [], set()
+
+    def add(row):
+        if row and row["id"] not in seen:
+            seen.add(row["id"])
+            windows.append(row)
+
+    percent = quota_number(root.get("creditUsagePercent"))
+    if percent is not None:
+        add(quota_window(
+            "grok", "grok-{}".format(kind), kind, label, percent,
+            window_seconds=duration, reset_at=end, now=now,
+        ))
+    products = [
+        row for row in (root.get("productUsage") or []) if isinstance(row, dict)
+    ]
+    for index, product in enumerate(products):
+        used = quota_number(product.get("usagePercent"))
+        name = str(product.get("product") or "").strip() or "Product {}".format(index + 1)
+        if used is None:
+            continue
+        if percent is not None and abs(used - percent) < 0.05:
+            continue
+        add(quota_window(
+            "grok", "grok-product-{}".format(quota_slug(name)), "extra", name, used,
+            window_seconds=duration, reset_at=end, now=now,
+        ))
+    cap = _money_val(root.get("onDemandCap"))
+    used_on_demand = _money_val(root.get("onDemandUsed"))
+    if cap is not None and cap > 0 and used_on_demand is not None:
+        add(quota_window(
+            "grok", "grok-on-demand", "extra", "On-demand",
+            used_on_demand / cap * 100.0,
+            window_seconds=duration, reset_at=end, now=now,
+        ))
+    missing = []
+    if not any(row.get("kind") == "session" for row in windows):
+        missing.append("Session")
+    if not any(row.get("kind") == "weekly" for row in windows):
+        missing.append("Weekly")
+    coverage_note = quota_coverage_note("Grok", missing)
+    if not windows:
+        return quota_provider(
+            "grok", "Grok", "unavailable", "Grok CLI billing",
+            error="This Grok account does not report quota windows.",
+            coverage_note=coverage_note,
+        )
+    return quota_provider(
+        "grok", "Grok", "ok", "Grok CLI billing", windows=windows,
+        plan="Grok Build", coverage_note=coverage_note,
+    )
+
+
+def load_quota(token_loader, http_json, now=None, opener=None):
+    token = token_loader(now=now)
+    payload = http_json(
+        BILLING_URL,
+        headers={
+            "Authorization": "Bearer {}".format(token),
+            "Accept": "application/json",
+            "User-Agent": "TokenMeter/0.1",
+        },
+        opener=opener,
+    )
+    return parse_quota(payload, now=now)

--- a/token_meter/runtimes/grok.py
+++ b/token_meter/runtimes/grok.py
@@ -35,7 +35,7 @@ MAX_EVENT_ROWS = 20_000
 MAX_SOURCES = 2_000
 MAX_TURNS = 2_000
 MAX_TOOLS = 2_000
-COST_TICKS_PER_USD = 1_000_000_000.0
+COST_TICKS_PER_USD = 10_000_000_000.0
 SESSION_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{7,127}$")
 
 
@@ -154,7 +154,7 @@ def _session_totals(usage):
     output_tokens = _integer(session.get("outputTokens"))
     cache_read = _integer(session.get("cachedReadTokens"))
     cache_write = _integer(session.get("cacheCreationTokens"))
-    cost = _cost_from_ticks(session.get("costUsdTicks"))
+    cost = _recorded_cost(session, usage)
     token_available = input_tokens is not None and output_tokens is not None
     cache_available = cache_read is not None and cache_write is not None
     if not token_available and cost is None:
@@ -205,11 +205,27 @@ def _tool_category(name):
     return "other"
 
 
+def _incomplete_cost(record):
+    if not isinstance(record, dict):
+        return False
+    return record.get("costIsPartial") is True or record.get("usageIsIncomplete") is True
+
+
 def _cost_from_ticks(ticks):
     ticks = _integer(ticks)
-    if ticks is None:
+    if ticks is None or ticks <= 0:
         return None
     return ticks / COST_TICKS_PER_USD
+
+
+def _recorded_cost(*records):
+    for record in records:
+        if _incomplete_cost(record):
+            return None
+    for record in records:
+        if isinstance(record, dict) and "costUsdTicks" in record:
+            return _cost_from_ticks(record.get("costUsdTicks"))
+    return None
 
 
 def _decode_cwd(encoded, group_dir):
@@ -419,7 +435,7 @@ class GrokRuntimeAdapter:
         cache_read = _integer(row.get("cachedReadTokens"))
         cache_write = _integer(row.get("cacheCreationTokens"))
         reasoning = _integer(row.get("reasoningTokens")) or 0
-        cost = _cost_from_ticks(row.get("costUsdTicks"))
+        cost = _recorded_cost(row)
         token_available = input_tokens is not None and output_tokens is not None
         cache_available = cache_read is not None and cache_write is not None
         context_tokens = 0

--- a/token_meter/runtimes/grok.py
+++ b/token_meter/runtimes/grok.py
@@ -232,7 +232,7 @@ class GrokRuntimeAdapter:
     descriptor = RuntimeDescriptor(
         "grok",
         "Grok",
-        frozenset(("sessions", "models", "tools")),
+        frozenset(("sessions", "models", "tools", "quota")),
         "runtime.generic",
         "runtime-neutral",
         None,

--- a/token_meter/runtimes/grok.py
+++ b/token_meter/runtimes/grok.py
@@ -1,0 +1,980 @@
+"""Native read-only adapter for Grok Build local session evidence."""
+
+import json
+import math
+import os
+import re
+import time
+from collections import defaultdict
+from datetime import datetime
+from pathlib import Path
+from urllib.parse import unquote
+
+from token_meter.contracts import (
+    DeletionPlan,
+    DetailLevel,
+    EvidenceBasis,
+    EvidenceValue,
+    ModelRef,
+    NormalizedSession,
+    ParseWarning,
+    RuntimeDescriptor,
+    SessionSource,
+    SourceLocator,
+    SourceRevision,
+    TimingEvidence,
+    ToolEvent,
+    UsageEvidence,
+)
+from token_meter.domain.timing import merge_execution_intervals, performance_summary
+
+
+MAX_JSON_BYTES = 8 * 1024 * 1024
+MAX_EVENT_BYTES = 32 * 1024 * 1024
+MAX_EVENT_ROWS = 20_000
+MAX_SOURCES = 2_000
+MAX_TURNS = 2_000
+MAX_TOOLS = 2_000
+COST_TICKS_PER_USD = 1_000_000_000.0
+SESSION_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{7,127}$")
+
+
+def _file_signature(path):
+    try:
+        stat = os.stat(path)
+        return str(stat.st_mtime_ns), str(stat.st_size)
+    except OSError:
+        return "0", "0"
+
+
+def _mtime(path):
+    try:
+        return os.path.getmtime(path)
+    except OSError:
+        return 0.0
+
+
+def _timestamp(value):
+    if isinstance(value, bool) or value is None:
+        return 0.0
+    if isinstance(value, (int, float)):
+        value = float(value)
+        return value / 1000.0 if value > 10_000_000_000 else value
+    if not isinstance(value, str):
+        return 0.0
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _integer(value):
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        number = int(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    return number if number >= 0 else None
+
+
+def _number(value):
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    return number if math.isfinite(number) and number >= 0 else None
+
+
+def _read_json(path, limit=MAX_JSON_BYTES):
+    try:
+        if os.path.getsize(path) > limit:
+            return None, True
+        with open(path, encoding="utf-8") as handle:
+            value = json.load(handle)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, TypeError, ValueError):
+        return None, False
+    return (value, False) if isinstance(value, dict) else (None, False)
+
+
+_EVENT_TYPES = frozenset((
+    "turn_started", "turn_ended", "first_token",
+    "tool_started", "tool_completed",
+))
+
+
+def _read_events(path):
+    rows = []
+    corrupt = 0
+    truncated = False
+    try:
+        if os.path.getsize(path) > MAX_EVENT_BYTES:
+            return (), 0, True
+        with open(path, encoding="utf-8") as handle:
+            for line in handle:
+                if not line.strip():
+                    continue
+                if not any(kind in line for kind in _EVENT_TYPES):
+                    continue
+                try:
+                    row = json.loads(line)
+                except (TypeError, ValueError, json.JSONDecodeError):
+                    corrupt += 1
+                    continue
+                if not isinstance(row, dict):
+                    corrupt += 1
+                    continue
+                kind = str(row.get("type") or "")
+                if kind not in _EVENT_TYPES:
+                    continue
+                if len(rows) >= MAX_EVENT_ROWS:
+                    truncated = True
+                    break
+                rows.append({
+                    "type": kind,
+                    "ts": _timestamp(row.get("ts")),
+                    "turn_number": _integer(row.get("turn_number")),
+                    "model_id": str(row.get("model_id") or ""),
+                    "tool_name": str(row.get("tool_name") or ""),
+                    "outcome": str(row.get("outcome") or ""),
+                    "duration_ms": _number(row.get("duration_ms")),
+                })
+    except OSError:
+        return (), 0, False
+    return tuple(rows), corrupt, truncated
+
+
+def _session_totals(usage):
+    session = usage.get("session") if isinstance(usage, dict) else None
+    if not isinstance(session, dict):
+        return None
+    input_tokens = _integer(session.get("inputTokens"))
+    output_tokens = _integer(session.get("outputTokens"))
+    cache_read = _integer(session.get("cachedReadTokens"))
+    cache_write = _integer(session.get("cacheCreationTokens"))
+    cost = _cost_from_ticks(session.get("costUsdTicks"))
+    token_available = input_tokens is not None and output_tokens is not None
+    cache_available = cache_read is not None and cache_write is not None
+    if not token_available and cost is None:
+        return None
+    return {
+        "input_tokens": input_tokens or 0,
+        "output_tokens": output_tokens or 0,
+        "cache_read_tokens": cache_read or 0,
+        "cache_write_tokens": cache_write or 0,
+        "cost": cost,
+        "token_available": token_available,
+        "cache_available": cache_available,
+        "cost_available": cost is not None,
+    }
+
+
+def _normalize_model(value):
+    value = str(value or "").strip().lower()
+    return value or "unknown-model"
+
+
+def model_ref_for(model):
+    model = _normalize_model(model)
+    if model.startswith("grok-"):
+        return ModelRef("xai", model)
+    return ModelRef("unknown-model-provider", model)
+
+
+def _normalize_tool_name(value):
+    value = str(value or "tool").strip()
+    value = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", value)
+    value = re.sub(r"[^A-Za-z0-9_.-]+", "_", value).strip("_").lower()
+    return value or "tool"
+
+
+def _tool_category(name):
+    name = str(name or "").lower()
+    if any(part in name for part in ("command", "shell", "bash", "terminal", "exec")):
+        return "shell"
+    if any(part in name for part in ("read", "write", "file", "directory", "edit", "search_replace")):
+        return "filesystem"
+    if any(part in name for part in ("grep", "search", "find", "glob")):
+        return "search"
+    if any(part in name for part in ("browser", "web", "url")):
+        return "browser"
+    if any(part in name for part in ("fetch", "retrieve", "lookup")):
+        return "retrieval"
+    return "other"
+
+
+def _cost_from_ticks(ticks):
+    ticks = _integer(ticks)
+    if ticks is None:
+        return None
+    return ticks / COST_TICKS_PER_USD
+
+
+def _decode_cwd(encoded, group_dir):
+    cwd_file = os.path.join(group_dir, ".cwd")
+    if os.path.isfile(cwd_file) and not os.path.islink(cwd_file):
+        try:
+            with open(cwd_file, encoding="utf-8") as handle:
+                value = handle.readline().strip()
+            if value.startswith("/"):
+                return value
+        except OSError:
+            pass
+    decoded = unquote(str(encoded or ""), errors="replace")
+    return decoded if decoded.startswith("/") else ""
+
+
+class GrokRuntimeAdapter:
+    """Discover Grok Build session directories and expose no message content."""
+
+    descriptor = RuntimeDescriptor(
+        "grok",
+        "Grok",
+        frozenset(("sessions", "models", "tools")),
+        "runtime.generic",
+        "runtime-neutral",
+        None,
+    )
+
+    def __init__(self, grok_home, project_resolver=None, compatibility=None):
+        self.grok_home = Path(os.path.abspath(os.path.expanduser(str(grok_home))))
+        self.project_resolver = project_resolver or (lambda value: value)
+        self.compatibility = dict(compatibility or {})
+        self._metadata_cache = {}
+
+    def _owned_path(self, path):
+        path = os.path.realpath(os.path.abspath(os.path.expanduser(str(path or ""))))
+        root = os.path.realpath(str(self.grok_home))
+        try:
+            return os.path.commonpath((path, root)) == root
+        except ValueError:
+            return False
+
+    def _session_dirs(self):
+        root = self.grok_home / "sessions"
+        if not root.is_dir():
+            return ()
+        found = []
+        try:
+            groups = sorted(root.iterdir(), key=lambda path: path.name)
+        except OSError:
+            return ()
+        for group in groups:
+            if not group.is_dir() or group.is_symlink() or not self._owned_path(group):
+                continue
+            try:
+                children = sorted(group.iterdir(), key=lambda path: path.name)
+            except OSError:
+                continue
+            for child in children:
+                if len(found) >= MAX_SOURCES:
+                    return tuple(found)
+                if not child.is_dir() or child.is_symlink():
+                    continue
+                if not SESSION_ID_RE.fullmatch(child.name):
+                    continue
+                summary = child / "summary.json"
+                if summary.is_file() and not summary.is_symlink() and self._owned_path(summary):
+                    found.append(child)
+        return tuple(found)
+
+    def _metadata(self, session_dir):
+        summary_path = str(session_dir / "summary.json")
+        usage_path = str(session_dir / "usage.json")
+        signals_path = str(session_dir / "signals.json")
+        events_path = str(session_dir / "events.jsonl")
+        signature = (
+            *_file_signature(summary_path),
+            *_file_signature(usage_path),
+            *_file_signature(signals_path),
+            *_file_signature(events_path),
+        )
+        cached = self._metadata_cache.get(summary_path)
+        if cached and cached[0] == signature:
+            return dict(cached[1]) if cached[1] else None
+        summary, _ = _read_json(summary_path)
+        info = summary.get("info") if isinstance(summary, dict) else None
+        session_id = ""
+        cwd = ""
+        if isinstance(info, dict):
+            session_id = str(info.get("id") or "").strip()
+            cwd = str(info.get("cwd") or "").strip()
+        session_id = session_id or session_dir.name
+        if not SESSION_ID_RE.fullmatch(session_id):
+            result = None
+        else:
+            if not cwd:
+                cwd = _decode_cwd(session_dir.parent.name, str(session_dir.parent))
+            model = ""
+            if isinstance(summary, dict):
+                model = str(summary.get("current_model_id") or "")
+            usage, _ = _read_json(usage_path)
+            if not model and isinstance(usage, dict):
+                session = usage.get("session") if isinstance(usage.get("session"), dict) else {}
+                model = str(session.get("primaryModelId") or "")
+            model_ref = model_ref_for(model)
+            mtime = max(
+                _mtime(summary_path), _mtime(usage_path),
+                _mtime(signals_path), _mtime(events_path),
+            )
+            result = {
+                "provider": "grok", "client": "grok", "label": "Grok", "runtime": "Grok",
+                "id": session_id, "session": session_id,
+                "path": summary_path,
+                "project": self.project_resolver(cwd) or "",
+                "mtime": mtime, "signature_mtime": mtime, "title": "Grok session",
+                "model": model_ref.model_id, "model_provider": model_ref.provider_id,
+                "source_kind": "grok_session",
+            }
+        self._metadata_cache[summary_path] = (signature, result)
+        if len(self._metadata_cache) > MAX_SOURCES:
+            self._metadata_cache.pop(next(iter(self._metadata_cache)), None)
+        return dict(result) if result else None
+
+    def _legacy_records(self):
+        records = [self._metadata(path) for path in self._session_dirs()]
+        records = [record for record in records if record is not None]
+        return tuple(sorted(
+            records,
+            key=lambda record: (-float(record.get("mtime") or 0), record["id"], record["path"]),
+        ))
+
+    def discover_legacy(self, context):
+        del context
+        return self._legacy_records()
+
+    def discover(self, context):
+        del context
+        result = []
+        for record in self._legacy_records():
+            model = model_ref_for(record.get("model"))
+            result.append(SessionSource(
+                runtime_id=self.descriptor.runtime_id,
+                client_id="grok",
+                session_id=record["id"],
+                display_label="Grok",
+                project=record.get("project") or None,
+                locator=SourceLocator("file", record["path"]),
+                activity_mtime=record["mtime"],
+                revision=self._revision(record["path"]),
+                model_ref=model,
+                account_provider_id=None,
+            ))
+        return tuple(result)
+
+    def _revision(self, summary_path):
+        session_dir = os.path.dirname(summary_path)
+        return SourceRevision((
+            "grok-session",
+            *_file_signature(summary_path),
+            *_file_signature(os.path.join(session_dir, "usage.json")),
+            *_file_signature(os.path.join(session_dir, "events.jsonl")),
+        ))
+
+    def current_revision(self, source):
+        path = source.locator.value if isinstance(source, SessionSource) else source.get("path", "")
+        return self._revision(path)
+
+    def _parsed(self, summary_path):
+        if not self._owned_path(summary_path):
+            return {"turns": (), "corrupt": 0, "truncated": False}
+        session_dir = os.path.dirname(summary_path)
+        usage, usage_truncated = _read_json(os.path.join(session_dir, "usage.json"))
+        events, corrupt, events_truncated = _read_events(os.path.join(session_dir, "events.jsonl"))
+        signals, _ = _read_json(os.path.join(session_dir, "signals.json"))
+        summary, _ = _read_json(summary_path)
+        model = ""
+        if isinstance(summary, dict):
+            model = str(summary.get("current_model_id") or "")
+        session_usage = usage.get("session") if isinstance(usage, dict) else None
+        if not model and isinstance(session_usage, dict):
+            model = str(session_usage.get("primaryModelId") or "")
+        if not model and isinstance(signals, dict):
+            model = str(signals.get("primaryModelId") or "")
+        model = model_ref_for(model).model_id
+        event_turns = self._event_turns(events, model)
+        usage_turns = []
+        if isinstance(usage, dict):
+            for row in usage.get("turns") or ():
+                if not isinstance(row, dict) or len(usage_turns) >= MAX_TURNS:
+                    continue
+                usage_turns.append(self._usage_turn(row, model, len(usage_turns) + 1))
+            if not usage_turns and isinstance(session_usage, dict):
+                usage_turns.append(self._usage_turn(session_usage, model, 1))
+        turns = self._merge_turns(usage_turns, event_turns, model)
+        return {
+            "turns": tuple(turns[:MAX_TURNS]),
+            "session_totals": _session_totals(usage),
+            "corrupt": corrupt,
+            "truncated": bool(usage_truncated or events_truncated),
+        }
+
+    def _usage_turn(self, row, default_model, index):
+        start = _timestamp(row.get("startedAt") or row.get("started_at"))
+        end = _timestamp(row.get("endedAt") or row.get("ended_at"))
+        input_tokens = _integer(row.get("inputTokens"))
+        output_tokens = _integer(row.get("outputTokens"))
+        cache_read = _integer(row.get("cachedReadTokens"))
+        cache_write = _integer(row.get("cacheCreationTokens"))
+        reasoning = _integer(row.get("reasoningTokens")) or 0
+        cost = _cost_from_ticks(row.get("costUsdTicks"))
+        token_available = input_tokens is not None and output_tokens is not None
+        cache_available = cache_read is not None and cache_write is not None
+        context_tokens = 0
+        if token_available and cache_available:
+            context_tokens = input_tokens + cache_read + cache_write
+        return {
+            "index": _integer(row.get("turnNumber")) or index,
+            "start": start, "end": end or start,
+            "model": model_ref_for(row.get("primaryModelId") or default_model).model_id,
+            "input_tokens": input_tokens or 0,
+            "output_tokens": output_tokens or 0,
+            "reasoning_tokens": min(reasoning, output_tokens or reasoning),
+            "cache_read_tokens": cache_read or 0,
+            "cache_write_tokens": cache_write or 0,
+            "token_available": token_available,
+            "cache_available": cache_available,
+            "context_available": token_available and cache_available,
+            "context_tokens": context_tokens,
+            "cost": cost,
+            "ttft_s": None,
+            "tools": [],
+        }
+
+    def _event_turns(self, events, default_model):
+        turns = []
+        current = None
+        pending_first = None
+        for event in events:
+            kind = event["type"]
+            ts = event["ts"]
+            if kind == "turn_started" or (current is None and kind != "turn_ended"):
+                if kind == "turn_started" or current is None:
+                    if kind == "turn_started":
+                        current = {
+                            "index": event["turn_number"] or (len(turns) + 1),
+                            "start": ts, "end": ts,
+                            "model": model_ref_for(event["model_id"] or default_model).model_id,
+                            "tools": [], "ttft_s": None,
+                        }
+                        pending_first = ts
+                        turns.append(current)
+            if current is None:
+                continue
+            if kind == "first_token" and pending_first and ts >= pending_first and current["ttft_s"] is None:
+                current["ttft_s"] = max(0.0, ts - pending_first)
+            if kind == "tool_completed" and event["tool_name"] and len(current["tools"]) < MAX_TOOLS:
+                current["tools"].append({
+                    "id": "{}:{}".format(current["index"], len(current["tools"]) + 1),
+                    "name": _normalize_tool_name(event["tool_name"]),
+                    "category": _tool_category(event["tool_name"]),
+                    "result_available": True,
+                    "error": event["outcome"] in {"error", "failed", "failure"},
+                })
+            if ts:
+                current["end"] = max(current["end"] or ts, ts)
+            if kind == "turn_ended":
+                pending_first = None
+                current = None
+        return turns
+
+    def _merge_turns(self, usage_turns, event_turns, default_model):
+        if not usage_turns and not event_turns:
+            return [{
+                "index": 1, "start": 0.0, "end": 0.0, "model": default_model,
+                "input_tokens": 0, "output_tokens": 0, "reasoning_tokens": 0,
+                "cache_read_tokens": 0, "cache_write_tokens": 0,
+                "token_available": False, "cache_available": False,
+                "context_available": False, "context_tokens": 0, "cost": None,
+                "ttft_s": None, "tools": [],
+            }]
+        if not usage_turns:
+            merged = []
+            for event in event_turns:
+                merged.append({
+                    "index": event["index"], "start": event["start"], "end": event["end"],
+                    "model": event["model"] or default_model,
+                    "input_tokens": 0, "output_tokens": 0, "reasoning_tokens": 0,
+                    "cache_read_tokens": 0, "cache_write_tokens": 0,
+                    "token_available": False, "cache_available": False,
+                    "context_available": False, "context_tokens": 0, "cost": None,
+                    "ttft_s": event.get("ttft_s"), "tools": event.get("tools") or [],
+                })
+            return merged
+        by_index = {turn["index"]: turn for turn in event_turns}
+        merged = []
+        for usage in usage_turns:
+            event = by_index.get(usage["index"])
+            if event:
+                if not usage["start"]:
+                    usage["start"] = event["start"]
+                if not usage["end"] or usage["end"] < usage["start"]:
+                    usage["end"] = event["end"] or usage["start"]
+                usage["ttft_s"] = event.get("ttft_s")
+                usage["tools"] = event.get("tools") or []
+                if event.get("model"):
+                    usage["model"] = event["model"]
+            merged.append(usage)
+        used = {turn["index"] for turn in usage_turns}
+        for event in event_turns:
+            if event["index"] in used:
+                continue
+            merged.append({
+                "index": event["index"], "start": event["start"], "end": event["end"],
+                "model": event["model"] or default_model,
+                "input_tokens": 0, "output_tokens": 0, "reasoning_tokens": 0,
+                "cache_read_tokens": 0, "cache_write_tokens": 0,
+                "token_available": False, "cache_available": False,
+                "context_available": False, "context_tokens": 0, "cost": None,
+                "ttft_s": event.get("ttft_s"), "tools": event.get("tools") or [],
+            })
+        merged.sort(key=lambda row: (row["start"] or 0, row["index"]))
+        for index, turn in enumerate(merged, 1):
+            turn["index"] = index
+        return merged
+
+    @staticmethod
+    def _available(value, available, basis=EvidenceBasis.MEASURED):
+        return EvidenceValue(value, basis) if available else EvidenceValue.unavailable()
+
+    def load(self, source, detail):
+        if isinstance(source, dict):
+            return self.recompute_legacy(source)
+        if not isinstance(source, SessionSource):
+            raise TypeError("native load requires SessionSource")
+        if source.runtime_id != self.descriptor.runtime_id:
+            raise ValueError("source belongs to another runtime")
+        parsed = self._parsed(source.locator.value)
+        turns = parsed["turns"]
+        session_totals = parsed.get("session_totals") or {}
+        usage_turns = [turn for turn in turns if turn["token_available"]]
+        cache_turns = [turn for turn in turns if turn["cache_available"]]
+        cost_turns = [turn for turn in turns if turn["cost"] is not None]
+        tokens_available = bool(session_totals.get("token_available") or usage_turns)
+        cache_available = bool(session_totals.get("cache_available") or cache_turns)
+        cost_available = bool(session_totals.get("cost_available") or cost_turns)
+        intervals = [
+            (turn["start"], turn["end"]) for turn in turns
+            if turn["start"] and turn["end"] >= turn["start"]
+        ]
+        tools = []
+        for turn in turns:
+            for tool in turn["tools"]:
+                tools.append(ToolEvent(tool["name"], tool["category"], tool.get("error") and "error" or "success"))
+        warning_codes = []
+        if parsed["truncated"]:
+            warning_codes.append("truncated")
+        if not tokens_available:
+            warning_codes.append("partial")
+        started = min((turn["start"] for turn in turns if turn["start"]), default=0) or None
+        ended = max((turn["end"] for turn in turns if turn["end"]), default=0) or None
+        if session_totals.get("token_available"):
+            input_tokens = session_totals["input_tokens"]
+            output_tokens = session_totals["output_tokens"]
+        else:
+            input_tokens = sum(turn["input_tokens"] for turn in usage_turns)
+            output_tokens = sum(turn["output_tokens"] for turn in usage_turns)
+        if session_totals.get("cache_available"):
+            cache_read = session_totals["cache_read_tokens"]
+            cache_write = session_totals["cache_write_tokens"]
+        else:
+            cache_read = sum(turn["cache_read_tokens"] for turn in cache_turns)
+            cache_write = sum(turn["cache_write_tokens"] for turn in cache_turns)
+        if session_totals.get("cost_available"):
+            cost = session_totals["cost"] or 0.0
+        else:
+            cost = sum(turn["cost"] or 0.0 for turn in cost_turns)
+        del detail
+        return NormalizedSession(
+            source=source,
+            started_at=datetime.fromtimestamp(started) if started else None,
+            ended_at=datetime.fromtimestamp(ended) if ended else None,
+            usage=UsageEvidence(
+                input_tokens=self._available(input_tokens, tokens_available),
+                output_tokens=self._available(output_tokens, tokens_available),
+                cache_read_tokens=self._available(cache_read, cache_available),
+                cache_write_tokens=self._available(cache_write, cache_available),
+                cost_usd=self._available(cost, cost_available, EvidenceBasis.ESTIMATED),
+            ),
+            timing=TimingEvidence(
+                active_seconds=self._available(
+                    merge_execution_intervals(intervals), bool(intervals), EvidenceBasis.INFERRED,
+                ),
+                wait_seconds=EvidenceValue.unavailable(),
+                ttft_seconds=self._available(
+                    next((turn["ttft_s"] for turn in reversed(turns) if turn.get("ttft_s") is not None), None),
+                    any(turn.get("ttft_s") is not None for turn in turns),
+                    EvidenceBasis.MEASURED,
+                ),
+            ),
+            tools=tuple(tools),
+            turns=(),
+            pricing_basis="Grok-recorded local cost; Token Meter did not price this runtime.",
+            capabilities=self.descriptor.capabilities,
+            warnings=tuple(ParseWarning(code, "Grok evidence is incomplete.") for code in warning_codes),
+            detail=DetailLevel.SUMMARY,
+        )
+
+    def _require_compatibility(self):
+        required = (
+            "add_model_daily", "add_model_summary", "analysis_block", "build_state",
+            "context_sample_limit", "metric_availability", "summarize_tool_evidence",
+            "summary_row", "tool_identity", "tool_summary", "trace_event",
+        )
+        missing = [name for name in required if name not in self.compatibility]
+        if missing:
+            raise RuntimeError("Grok adapter is missing compatibility helpers: {}".format(
+                ", ".join(missing)
+            ))
+        return self.compatibility
+
+    def _legacy_rows(self, source):
+        return self._parsed(source.get("path") or "")["turns"]
+
+    def _legacy_usage(self, turn):
+        return {
+            "input_tokens": turn["input_tokens"],
+            "output_tokens": turn["output_tokens"],
+            "cache_read_input_tokens": turn["cache_read_tokens"],
+            "cache_creation_input_tokens": turn["cache_write_tokens"],
+        }
+
+    def recompute_legacy(self, source):
+        compat = self._require_compatibility()
+        parsed = self._parsed(source.get("path") or "")
+        turns = parsed["turns"]
+        if not turns:
+            return None
+        session_totals = parsed.get("session_totals") or {}
+        tot = {"input": 0, "cache_write": 0, "cache_read": 0, "output": 0}
+        cost = {"input": 0.0, "cache_write": 0.0, "cache_read": 0.0, "output": 0.0}
+        model_tok, model_cost = defaultdict(int), defaultdict(float)
+        series, executions, trace, wait_samples, intervals = [], [], [], [], []
+        all_tokens_available = bool(
+            session_totals.get("token_available")
+            or any(turn["token_available"] for turn in turns)
+        )
+        all_cache_available = bool(
+            session_totals.get("cache_available")
+            or any(turn["cache_available"] for turn in turns)
+        )
+        all_cost_available = bool(
+            session_totals.get("cost_available")
+            or any(turn["cost"] is not None for turn in turns)
+        )
+        for turn in turns:
+            execution_cost = float(turn["cost"] or 0.0)
+            cost_available = turn["cost"] is not None
+            usage = self._legacy_usage(turn)
+            tools = []
+            for tool in turn["tools"]:
+                ident = compat["tool_identity"](tool["name"])
+                tools.append({
+                    **ident, "id": tool["id"], "call_id": tool["id"],
+                    "args_chars": 0, "output_chars": 0, "output_tokens": 0,
+                    "result_available": bool(tool.get("result_available")),
+                    "error": bool(tool.get("error")), "skills": [],
+                })
+            total = sum(usage.values())
+            timing_available = bool(turn["start"] and turn["end"] >= turn["start"])
+            availability = compat["metric_availability"](
+                "grok", cost=cost_available, tokens=turn["token_available"],
+                input_tokens=turn["token_available"], output_tokens=turn["token_available"],
+                cache=turn["cache_available"], throughput=False,
+                context=turn["context_available"], timing=timing_available,
+                tool_results=any(tool["result_available"] for tool in tools),
+            )
+            duration = max(0.0, turn["end"] - turn["start"]) if timing_available else 0.0
+            series.append({
+                "i": turn["index"], "in": usage["input_tokens"], "out": usage["output_tokens"],
+                "cost": execution_cost, "fresh_input": usage["input_tokens"],
+                "cache": usage["cache_read_input_tokens"] + usage["cache_creation_input_tokens"],
+                "cache_read": usage["cache_read_input_tokens"],
+                "cache_write": usage["cache_creation_input_tokens"],
+                "think": bool(turn["reasoning_tokens"]),
+                "tools": len(tools), "side": False,
+                "reasoning": turn["reasoning_tokens"], "reasoning_ms": 0,
+                "context_pct": None, "context_tokens": turn["context_tokens"],
+                "user_message": "", "user_input": "", "availability": availability,
+            })
+            executions.append({
+                "id": "{}:{}".format(source["id"], turn["index"]), "idx": turn["index"],
+                "ts": turn["end"] or turn["start"],
+                "time": time.strftime("%H:%M", time.localtime(turn["end"] or turn["start"] or 0)),
+                "model": turn["model"],
+                "tokens": {
+                    "input": usage["input_tokens"], "output": usage["output_tokens"],
+                    "reasoning": turn["reasoning_tokens"], "retrieval": 0,
+                    "fresh_input": usage["input_tokens"],
+                    "cache": usage["cache_read_input_tokens"] + usage["cache_creation_input_tokens"],
+                    "cache_read": usage["cache_read_input_tokens"],
+                    "cache_write": usage["cache_creation_input_tokens"], "total": total,
+                },
+                "cost": execution_cost,
+                "cost_breakdown": {
+                    "input": execution_cost, "cache_write": 0.0, "cache_read": 0.0, "output": 0.0,
+                } if cost_available else {
+                    "input": 0.0, "cache_write": 0.0, "cache_read": 0.0, "output": 0.0,
+                },
+                "tools": tools, "tool_count": len(tools), "model_calls": 1,
+                "reasoning_tokens": turn["reasoning_tokens"],
+                "reasoning_duration_ms": 0,
+                "context_tokens": turn["context_tokens"],
+                "context_window": 0, "context_pct": None,
+                "duration_ms": duration * 1000 if duration else None,
+                "wait_duration_ms": duration * 1000 if duration else None,
+                "summary": "Execution {}: {} tools · {}".format(
+                    turn["index"], len(tools),
+                    "${:.3f} Grok estimate".format(execution_cost)
+                    if cost_available else "cost unavailable",
+                ),
+                "user_message": "", "user_input": "", "availability": availability,
+            })
+            trace.append(compat["trace_event"](
+                turn["start"], "user", "User input", "Content excluded", turn["index"],
+                severity="start", model=turn["model"], native_type="user",
+                native_subtype="user_message",
+            ))
+            for tool in tools:
+                trace.append(compat["trace_event"](
+                    turn["end"], "tool_call", tool["display"], "Payload excluded",
+                    turn["index"], tool=tool["name"],
+                    severity="warn" if tool.get("error") else "tool",
+                    model=turn["model"], native_type="tool_call", native_subtype="tool_call",
+                ))
+            trace.append(compat["trace_event"](
+                turn["end"], "complete", "Execution complete", "", turn["index"],
+                severity="good", model=turn["model"],
+                cost=execution_cost if cost_available else None,
+                native_type="assistant", native_subtype="agent_message",
+            ))
+            tot["input"] += usage["input_tokens"]
+            tot["cache_write"] += usage["cache_creation_input_tokens"]
+            tot["cache_read"] += usage["cache_read_input_tokens"]
+            tot["output"] += usage["output_tokens"]
+            if cost_available:
+                cost["input"] += execution_cost
+            model_tok[turn["model"]] += total
+            model_cost[turn["model"]] += execution_cost
+            if timing_available:
+                intervals.append((turn["start"], turn["end"]))
+                wait_samples.append({
+                    "provider": "grok", "model": turn["model"],
+                    "day": time.strftime("%Y-%m-%d", time.localtime(turn["end"])),
+                    "ts": turn["end"], "start_ts": turn["start"], "duration_s": duration,
+                    "generation_s": duration, "ttft_s": turn.get("ttft_s") or 0.0,
+                    "tool_calls": len(tools), "model_calls": 1,
+                    "output_tokens": usage["output_tokens"],
+                    "input_tokens": (usage["input_tokens"]
+                                     + usage["cache_read_input_tokens"]
+                                     + usage["cache_creation_input_tokens"]),
+                    "uncached_input_tokens": usage["input_tokens"],
+                    "cache_read_tokens": usage["cache_read_input_tokens"],
+                    "cache_write_tokens": usage["cache_creation_input_tokens"],
+                    "peak_input_tokens": turn["context_tokens"],
+                    "context_tokens": turn["context_tokens"],
+                    "timing_basis": "inferred",
+                })
+        if session_totals.get("token_available"):
+            tot = {
+                "input": session_totals["input_tokens"],
+                "cache_write": session_totals["cache_write_tokens"],
+                "cache_read": session_totals["cache_read_tokens"],
+                "output": session_totals["output_tokens"],
+            }
+        if session_totals.get("cost_available"):
+            cost = {
+                "input": float(session_totals["cost"] or 0.0),
+                "cache_write": 0.0, "cache_read": 0.0, "output": 0.0,
+            }
+        total_tokens, total_cost = sum(tot.values()), sum(cost.values())
+        tool_data = compat["tool_summary"](executions)
+        primary_model = max(model_tok, key=model_tok.get) if model_tok else source.get("model")
+        analyses = compat["analysis_block"](
+            tot, total_cost, 0, 0, 0.0, model_tok, model_cost, tool_data, 0.0, 0, len(executions),
+        )
+        active = merge_execution_intervals(intervals)
+        source = dict(source)
+        source["context_latest"] = executions[-1]["context_tokens"] if executions else 0
+        throughput = performance_summary(wait_samples, tot["output"])
+        context_available = bool(turns) and all(turn["context_available"] for turn in turns)
+        availability = compat["metric_availability"](
+            "grok", cost=all_cost_available, tokens=all_tokens_available,
+            input_tokens=all_tokens_available, output_tokens=all_tokens_available,
+            cache=all_cache_available, throughput=throughput["available"],
+            context=context_available, timing=bool(intervals),
+            tool_results=any(
+                tool.get("result_available")
+                for execution in executions for tool in execution["tools"]
+            ),
+        )
+        biggest = max(
+            ({"cost": execution["cost"], "idx": execution["idx"]} for execution in executions),
+            key=lambda row: row["cost"], default=None,
+        ) if all_cost_available else None
+        source["cache_savings_available"] = False
+        state = compat["build_state"](
+            source, tot, cost, total_tokens, total_cost, series, executions, trace,
+            {"reasoning": 0, "output": 0, "retrieval": 0, "coordination": 0},
+            analyses, [], min((turn["start"] for turn in turns if turn["start"]), default=0),
+            max((turn["end"] for turn in turns if turn["end"]), default=0), 0, biggest, 0,
+            True, primary_model,
+            "Grok-recorded local cost; Token Meter did not price this runtime.",
+            {"duration_s": active, "available": bool(intervals), "reported_executions": 0,
+             "observed_executions": len(intervals), "execution_count": len(executions),
+             "basis": "inferred"},
+            wait_samples, availability=availability,
+        )
+        state["throughput"] = throughput
+        state["semantic_available"] = False
+        return state
+
+    def summarize_legacy(self, source, unused=None):
+        del unused
+        compat = self._require_compatibility()
+        parsed = self._parsed(source.get("path") or "")
+        turns = parsed["turns"]
+        session_totals = parsed.get("session_totals") or {}
+        model_cost, model_tok, model_stats, model_daily = (
+            defaultdict(float), defaultdict(int), {}, {}
+        )
+        day_cost, tool_calls, intervals, models, wait_samples, context_samples = (
+            defaultdict(float), [], [], set(), [], []
+        )
+        total_cost = input_tokens = output_tokens = 0
+        all_tokens_available = bool(
+            session_totals.get("token_available")
+            or (turns and any(turn["token_available"] for turn in turns))
+        )
+        all_cache_available = bool(
+            session_totals.get("cache_available")
+            or (turns and any(turn["cache_available"] for turn in turns))
+        )
+        all_cost_available = bool(
+            session_totals.get("cost_available")
+            or (turns and any(turn["cost"] is not None for turn in turns))
+        )
+        all_context_available = bool(turns) and any(turn["context_available"] for turn in turns)
+        for turn in turns:
+            usage = self._legacy_usage(turn)
+            value = float(turn["cost"] or 0.0)
+            total = sum(usage.values())
+            input_tokens += usage["input_tokens"]
+            output_tokens += usage["output_tokens"]
+            total_cost += value
+            model_cost[turn["model"]] += value
+            model_tok[turn["model"]] += total
+            models.add(turn["model"])
+            compat["add_model_summary"](
+                model_stats, turn["model"], usage, value,
+                cost_available=turn["cost"] is not None,
+            )
+            compat["add_model_daily"](
+                model_daily, turn["model"], usage, value, turn["end"],
+                cost_available=turn["cost"] is not None,
+            )
+            if turn["end"]:
+                day_cost[time.strftime("%Y-%m-%d", time.localtime(turn["end"]))] += value
+            if turn["start"] and turn["end"] >= turn["start"]:
+                intervals.append((turn["start"], turn["end"]))
+                duration = turn["end"] - turn["start"]
+                context_samples.append(turn["context_tokens"])
+                wait_samples.append({
+                    "provider": "grok", "model": turn["model"],
+                    "day": time.strftime("%Y-%m-%d", time.localtime(turn["end"])),
+                    "ts": turn["end"], "start_ts": turn["start"],
+                    "duration_s": duration, "generation_s": duration,
+                    "ttft_s": turn.get("ttft_s") or 0.0,
+                    "tool_calls": len(turn["tools"]), "model_calls": 1,
+                    "output_tokens": usage["output_tokens"],
+                    "input_tokens": (usage["input_tokens"]
+                                     + usage["cache_read_input_tokens"]
+                                     + usage["cache_creation_input_tokens"]),
+                    "uncached_input_tokens": usage["input_tokens"],
+                    "cache_read_tokens": usage["cache_read_input_tokens"],
+                    "cache_write_tokens": usage["cache_creation_input_tokens"],
+                    "peak_input_tokens": turn["context_tokens"],
+                    "context_tokens": turn["context_tokens"],
+                    "timing_basis": "inferred",
+                })
+            for tool in turn["tools"]:
+                tool_calls.append({
+                    "name": tool["name"], "display": tool["name"].replace("_", " ").title(),
+                    "namespace": tool["category"], "kind": "tool", "output_tokens": 0,
+                    "error": bool(tool.get("error")), "ts": turn["end"], "skills": [],
+                })
+        if session_totals.get("token_available"):
+            input_tokens = session_totals["input_tokens"]
+            output_tokens = session_totals["output_tokens"]
+        if session_totals.get("cost_available"):
+            total_cost = float(session_totals["cost"] or 0.0)
+        throughput = performance_summary(wait_samples, output_tokens)
+        availability = compat["metric_availability"](
+            "grok", cost=all_cost_available, tokens=all_tokens_available,
+            input_tokens=all_tokens_available, output_tokens=all_tokens_available,
+            cache=all_cache_available, throughput=throughput["available"],
+            context=all_context_available, timing=bool(intervals),
+            tool_results=False,
+        )
+        for stats in (*model_stats.values(), *model_daily.values()):
+            stats["availability"] = compat["metric_availability"](
+                "grok", cost=int(stats.get("cost_covered_executions") or 0) > 0,
+                tokens=all_tokens_available, input_tokens=all_tokens_available,
+                output_tokens=all_tokens_available, cache=all_cache_available,
+                throughput=throughput["available"], context=all_context_available,
+                timing=False, tool_results=False,
+            )
+        row = compat["summary_row"](
+            source, None, total_cost, sum(model_tok.values()), len(turns), models,
+            min((turn["start"] for turn in turns if turn["start"]), default=0),
+            max((turn["end"] for turn in turns if turn["end"]), default=0),
+            model_cost, model_tok, day_cost, True,
+            {"duration_s": merge_execution_intervals(intervals), "available": bool(intervals),
+             "basis": "inferred"}, input_tokens, output_tokens, model_stats,
+            list(model_daily.values()), wait_samples, wait_samples, availability,
+        )
+        row["primary_model"] = max(model_tok, key=model_tok.get) if model_tok else source.get("model")
+        row["context"] = {
+            "latest": context_samples[-1] if context_samples else 0,
+            "window": None, "latest_pct": None, "estimated": False,
+        }
+        row["_context_samples"] = context_samples[-compat["context_sample_limit"]:]
+        row["terminal"] = False
+        row["_tool_evidence"] = compat["summarize_tool_evidence"](tool_calls)
+        return row
+
+    def deletion_plan(self, source):
+        return DeletionPlan.deny("Grok sessions are read-only in Token Meter.")
+
+
+class GrokRuntimeAdapterProxy:
+    descriptor = GrokRuntimeAdapter.descriptor
+
+    def __init__(self, adapter_factory):
+        self._adapter_factory = adapter_factory
+
+    def _adapter(self):
+        adapter = self._adapter_factory()
+        if getattr(adapter, "load", None) is None or getattr(adapter, "discover", None) is None:
+            raise TypeError("adapter factory returned an invalid Grok adapter")
+        return adapter
+
+    def discover(self, context):
+        return self._adapter().discover(context)
+
+    def discover_legacy(self, context):
+        return self._adapter().discover_legacy(context)
+
+    def current_revision(self, source):
+        return self._adapter().current_revision(source)
+
+    def load(self, source, detail):
+        return self._adapter().load(source, detail)
+
+    def summarize_legacy(self, source, unused=None):
+        return self._adapter().summarize_legacy(source, unused)
+
+    def deletion_plan(self, source):
+        return self._adapter().deletion_plan(source)


### PR DESCRIPTION
Based on #43. Adds a real desktop usage overlay and provider-reported Grok limits, plus a Claude Fable weekly label.

## What changed

- Native usage widget on Linux (separate GTK overlay), Windows (topmost GDI+), and macOS (menu companion panel), with All / Claude / Codex / Cursor / Grok chips from `/menubar`.
- After drag, the overlay snaps to the nearer left or right edge of that monitor. Left docks open outward; right docks stay flush using the drawn window width so the tab is not clipped.
- Grok quotas come from the local CLI sign-in (`GROK_HOME` / `auth.json`) and the bounded billing endpoint. Missing windows stay unavailable rather than a fake 0%.
- Claude `weekly_scoped` limits keep the provider model name (Fable). The main weekly pool is not duplicated as "Scoped N".
- Linux tray no longer embeds WebKit; it spawns or quits the overlay process. The in-app dashboard drawer still works at `#widget`.

## Privacy

- No pasted keys. Credentials stay in existing local files, which remain gitignored.
- Tokens, refresh tokens, and account emails are not logged or included in this change.
- Fixture session names in tests are generic.

Merge after #43, or review `f3a40f1` for this delta on top of the Grok runtime adapter.