### PR TITLE
fix: hide Git delivery console windows on Windows

### DIFF
--- a/tests/test_git_delivery.py
+++ b/tests/test_git_delivery.py
@@ -148,6 +148,27 @@ class GitDeliveryScannerTests(unittest.TestCase):
 
         self.assertEqual(run.call_args.kwargs["env"]["PATH"], os.defpath)
 
+    def test_subprocess_runner_hides_windows_console(self):
+        completed = mock.Mock(returncode=0, stdout="", stderr="")
+        windows = meter.platform_services(
+            "windows",
+            environment={"USERPROFILE": r"C:\Users\example"},
+            home=r"C:\Users\example",
+        )
+        with mock.patch(
+            "token_meter.services.git_delivery.platform_services",
+            return_value=windows,
+        ), mock.patch(
+            "token_meter.services.git_delivery.subprocess.run",
+            return_value=completed,
+        ) as run:
+            meter.GitDeliveryService._subprocess_runner(
+                ["git", "--version"], timeout=1,
+            )
+
+        self.assertEqual(run.call_args.kwargs["creationflags"], 0x08000000)
+        self.assertTrue(run.call_args.kwargs["close_fds"])
+
     def test_scan_limits_generator_candidates_without_losing_limit_coverage(self):
         with tempfile.TemporaryDirectory() as tmp:
             service = meter.GitDeliveryService(

--- a/token_meter/services/git_delivery.py
+++ b/token_meter/services/git_delivery.py
@@ -10,6 +10,8 @@ import sqlite3
 import subprocess
 import threading
 
+from token_meter.platforms import ProcessPurpose, platform_services
+
 
 LEDGER_SCHEMA_VERSION = 1
 GIT_TIMEOUT_SECONDS = 10
@@ -355,6 +357,21 @@ class GitDeliveryService:
         }
 
     @staticmethod
+    def _platform_subprocess_kwargs():
+        """Match app._platform_subprocess_kwargs without importing app.py."""
+        options = platform_services().process_options(ProcessPurpose.DEFAULT)
+        if not options.supported:
+            return {}
+        kwargs = {}
+        if options.close_fds:
+            kwargs["close_fds"] = True
+        if options.start_new_session:
+            kwargs["start_new_session"] = True
+        if options.creation_flags:
+            kwargs["creationflags"] = options.creation_flags
+        return kwargs
+
+    @staticmethod
     def _subprocess_runner(argv, timeout):
         environment = {
             "PATH": os.environ.get("PATH") or os.defpath,
@@ -373,6 +390,7 @@ class GitDeliveryService:
             encoding="utf-8",
             errors="replace",
             env=environment,
+            **GitDeliveryService._platform_subprocess_kwargs(),
         )
 
     @staticmethod


### PR DESCRIPTION
## Summary
- Git delivery's `_subprocess_runner` now passes the same Windows `CREATE_NO_WINDOW` kwargs as the update-check path, so `git.exe` no longer flashes a console every 5 minutes.
- Helper lives on `GitDeliveryService` (not imported from `app.py`) to avoid a circular import.
- Adds `test_subprocess_runner_hides_windows_console`.

Fixes #32

## Validation
- `python -m unittest tests.GitDeliveryScannerTests.test_subprocess_runner_hides_windows_console tests.GitDeliveryScannerTests.test_git_command_uses_path_git` — pass
- Windows 11 (10.0.26200): Token Meter started with the patched `git_delivery.py`; no visible git consoles during watcher bursts
- `/health`: `ok=true`, `inventory_ready=true`; `meter.err.log` empty

Full `tests.test_git_delivery` still hits pre-existing Windows tempfile SQLite cleanup `WinError 32` on several tests; unrelated to this change.

## Notes
Same flags as #19 (`creationflags=0x08000000`, `close_fds=True`), different call site.

Made with [Cursor](https://cursor.com)